### PR TITLE
[Feat] add triton implement as cuda reference with TVM FFI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository is complemntary of "FlashFloat" with JIT Kernels
 
 <h2 id="Ultra-Low-Latency-TopK-Indexer">🔥 Ultra Low Latency TopK Indexer</h2>
 
-The introduction of the NSA (Native Sparse Attention) mechanism in DeepSeek V3.2 has become pivotal for mitigating inference latency in long-context language modeling. While the NSA top-k indexer playing a critical role in reducing computational overhead for DeepSeek V32 long context sequence modeling task[1], DeepSeek V4 [2] [3], recently, further pushes the context window limit to 1 million tokens where selecting top-2048 dimensions in hybrid sparse attention along from upto 1-M context is a prohibitive bottlenect upto **0.1** ms per layer per query token for agentic workflow.
+The introduction of the NSA (Native Sparse Attention) mechanism in DeepSeek V3.2 has become pivotal for mitigating inference latency in long-context language modeling. While the NSA top-k indexer playing a critical role in reducing computational overhead for DeepSeek V32 long context sequence modeling task [1], DeepSeek V4 [2] [3], recently, further pushes the context window limit to 1 million tokens where selecting top-2048 dimensions in hybrid sparse attention along from upto 1-M context is a prohibitive bottlenect upto **0.1** ms per layer per query token for agentic workflow.
 
 Leveraging the latest SGLang (2026.3) as the benchmark, we investigated the root causes of this latency bottleneck: kernels for conventional throughput-optimized GPU designs suffer from low device utilization in low-batch yet long context decoding scenarios, due to insufficient inter-block coordination [4]. For example, on-chip network has been maturely adopted for many years in the processors such as Graphcore IPU, Cerebras WSE and Groq LPU, but only being introduced into Hopper lately since 2022. By exploiting the limited on-chip communication capabilities of the Hopper architecture  (upto 8 blocks per cluster), through hardware-aware alorithm-hardware co-design, we achieve more than **50%** latency reduction in low-batch yet long context decoding scenarios, demonstrating the effectiveness of synergistic optimization and **NoC** for long-context inference:
 
@@ -49,7 +49,7 @@ We hence propose **Distributed Radix Sort via NoC** to extremely reduce decoding
 
 - First we compute historgram in parallel to reduce collision rates per block and then accumulate the histogram via NoC network before N-ways prefix sum and prove this is an effective method to reduce latency for a throughput oriented hardware design. 
 
-- Second, we enhance the linear mapping properties for radix sort in **NSA** problem for reduction of radix sorting iterations; insteadd of traditional top **8/11/13** bits [9] of IEEE FP32, FP16 format, we redesign the linear mapping such that $bin(x) >= bin(y)$, naturally deducing $x >= y$. 
+- Second, we enhance the linear mapping properties for radix sort in **NSA** problem for reduction of radix sorting iterations; instead of traditional top **8/11/13** bits [9] of IEEE FP32, FP16 format, we redesign the linear mapping such that $bin(x) >= bin(y)$, naturally deducing $x >= y$. 
 
   With this linear mapping design, we greatly reduced per block elements dropped in the threshold bin in redix sorting scheme and greatly reduce the residual numbers in later rounds.
   
@@ -59,7 +59,7 @@ We hence propose **Distributed Radix Sort via NoC** to extremely reduce decoding
 - Finally, when remainder elements reduced to **8**/**16**, we can simply use **CAS** operations to performa a **neat parallel sorting** in few cycles. This further reduce the latency overhead in the last round.
 <br/>
 
-Previously, L2 cache was commonly used in NVGPU/AMD GPU to trackle the problem, for example in MoE Align Block Multi Block Execution Algorithm published 2025 [5], we tackle this problem by introducing mathematically equivalent **unaligned parallel prefix sum**. With distributed radix sort, we further prove that on-chip network can further reduce latency of our kernel, facilitating new design of algorithm and software for **1-M** context.
+Previously, L2 cache was commonly used in NVGPU/AMD GPU to trackle the problem, for example in MoE Multi Block Block Size Align Sort Algorithm published 2025 [5], we tackle this problem by introducing mathematically equivalent **unaligned parallel prefix sum**. With distributed radix sort, we further prove that on-chip network can further reduce latency of our kernel, facilitating new design of algorithm and software for **1-M** context.
 
 <br/>
 
@@ -109,7 +109,7 @@ Traditional ballot-based voting relies on expensive bit-shifting operations (a m
 ```
 
 **Compared to TRT-LLM production codebase**
-The whole algorithm is  based on the earlier [two stages solution: topKPerRowDecode](https://github.com/NVIDIA/TensorRT-LLM/blame/v1.3.0rc10/cpp/tensorrt_llm/kernels/indexerTopK.cu), see [the details](https://github.com/NVIDIA/TensorRT-LLM/blame/628bb566050d693894ddf22de03581dd101747c3/cpp/tensorrt_llm/kernels/indexerTopK.cu#L743) in TRT-LLM **v1.3.0rc10**, this largely limited its peak perfmance in 1-M context scenarios.
+The whole algorithm is based on the earlier [two stages solution: topKPerRowDecode](https://github.com/NVIDIA/TensorRT-LLM/blame/v1.3.0rc10/cpp/tensorrt_llm/kernels/indexerTopK.cu), see [the details](https://github.com/NVIDIA/TensorRT-LLM/blame/628bb566050d693894ddf22de03581dd101747c3/cpp/tensorrt_llm/kernels/indexerTopK.cu#L743) in TRT-LLM **v1.3.0rc10**, this largely limited its peak perfmance in 1-M context scenarios.
 
 Recognizing this, the new approach [ballot-free kernel](https://github.com/NVIDIA/TensorRT-LLM/pull/12236) was integrated into TRT-LLM on March 16 2026. This implementation, written in cutedsl, leverages a Multi-CTA architecture with L2-cache-assisted synchronization to eliminate warp-level voting dependencies.
 

--- a/benchmark/moun/bench_symm_gemm.py
+++ b/benchmark/moun/bench_symm_gemm.py
@@ -1,0 +1,373 @@
+import itertools
+import os
+from typing import Any, Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+import triton.testing
+
+from jit_kernel.triton3_4.symm_gemm import thunder_moun_gemm, fp8_gemm_block_scaled
+
+from pdb import set_trace
+
+import time
+
+SEED = 42
+
+# CI environment detection
+IS_CI = (
+    os.getenv("CI", "false").lower() == "true"
+    or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+)
+
+
+OCP_FP8E4M3_MAX = 448.0
+FP8_MAX = OCP_FP8E4M3_MAX
+
+
+@triton.jit
+def fp8_weight_block_wise_quant_kernel(
+    x_ptr,
+    y_ptr,
+    s_ptr,
+    M,
+    N,
+    SCALED_BLOCK_SIZE_M: tl.constexpr,
+    SCALED_BLOCK_SIZE_N: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    n = tl.cdiv(N, SCALED_BLOCK_SIZE_M)
+    offs_m = pid_m * SCALED_BLOCK_SIZE_M + tl.arange(0, SCALED_BLOCK_SIZE_M)
+    offs_n = pid_n * SCALED_BLOCK_SIZE_N + tl.arange(0, SCALED_BLOCK_SIZE_N)
+    offs = offs_m[:, None] * N + offs_n[None, :]
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
+    s = tl.max(tl.abs(x)) / FP8_MAX
+    y = x / s
+    y = y.to(y_ptr.dtype.element_ty)
+    tl.store(y_ptr + offs, y, mask=mask)
+    tl.store(s_ptr + pid_m * n + pid_n, s)
+
+
+def fp8_weight_block_wise_quant(
+    x: torch.Tensor, scaled_block_size_m: int = 128, scaled_block_size_n: int = 128
+):
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert x.dim() == 2, "Input tensor must have 2 dimensions"
+    # assert x.size(0) % scaled_block_size_m == 0 and x.size(1) % scaled_block_size_n == 0, \
+    #     f"Dimensions of x must be divisible by scaled block_size (scale_block_size_m={scaled_block_size_m}x{scaled_block_size_n})"
+    M, N = x.size()
+    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    s = x.new_empty(
+        triton.cdiv(M, scaled_block_size_m),
+        triton.cdiv(N, scaled_block_size_n),
+        dtype=torch.float32,
+    )
+    grid = lambda meta: (
+        triton.cdiv(M, meta["SCALED_BLOCK_SIZE_M"]),
+        triton.cdiv(N, meta["SCALED_BLOCK_SIZE_N"]),
+    )
+    fp8_weight_block_wise_quant_kernel[grid](
+        x,
+        y,
+        s,
+        M,
+        N,
+        SCALED_BLOCK_SIZE_M=scaled_block_size_m,
+        SCALED_BLOCK_SIZE_N=scaled_block_size_n,
+        FP8_MAX=FP8_MAX,
+    )
+    return y, s
+
+
+@triton.jit
+def act_quant_kernel(
+    x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr, FP8_MAX: tl.constexpr
+):
+    """
+    Quantizes the input tensor `x_ptr` and stores the result in `y_ptr` and the scaling factor in `s_ptr`.
+
+    Args:
+        x_ptr (triton.Pointer): Pointer to the input tensor.
+        y_ptr (triton.Pointer): Pointer to the output tensor where quantized values will be stored.
+        s_ptr (triton.Pointer): Pointer to the output tensor where scaling factors will be stored.
+        BLOCK_SIZE (tl.constexpr): The size of the block to be processed by each program instance.
+
+    Returns:
+        None
+    """
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    x = tl.load(x_ptr + offs).to(tl.float32)
+    s = tl.max(tl.abs(x)) / FP8_MAX
+    y = x / s
+    y = y.to(y_ptr.dtype.element_ty)
+    tl.store(y_ptr + offs, y)
+    tl.store(s_ptr + pid, s)
+
+
+def act_quant(
+    x: torch.Tensor, block_size: int = 128
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantizes the input tensor `x` using block-wise quantization.
+
+    Args:
+        x (torch.Tensor): The input tensor to be quantized. Must be contiguous and its last dimension size must be divisible by `block_size`.
+        block_size (int, optional): The size of the blocks to be used for quantization. Default is 128.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
+            - The quantized tensor with dtype `torch.float8_e4m3fn`.
+            - A tensor of scaling factors with dtype `torch.float32`.
+    """
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert (
+        x.size(-1) % block_size == 0
+    ), f"Last dimension size must be divisible by block_size (block_size={block_size})"
+    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    s = x.new_empty(*x.size()[:-1], x.size(-1) // block_size, dtype=torch.float32)
+    grid = lambda meta: (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)
+    act_quant_kernel[grid](x, y, s, BLOCK_SIZE=block_size, FP8_MAX=FP8_MAX)
+    return y, s
+
+
+@triton.jit
+def act_quant_kernel(
+    x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr, FP8_MAX: tl.constexpr
+):
+    """
+    Quantizes the input tensor `x_ptr` and stores the result in `y_ptr` and the scaling factor in `s_ptr`.
+
+    Args:
+        x_ptr (triton.Pointer): Pointer to the input tensor.
+        y_ptr (triton.Pointer): Pointer to the output tensor where quantized values will be stored.
+        s_ptr (triton.Pointer): Pointer to the output tensor where scaling factors will be stored.
+        BLOCK_SIZE (tl.constexpr): The size of the block to be processed by each program instance.
+
+    Returns:
+        None
+    """
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    x = tl.load(x_ptr + offs).to(tl.float32)
+    s = tl.max(tl.abs(x)) / FP8_MAX
+    y = x / s
+    y = y.to(y_ptr.dtype.element_ty)
+    tl.store(y_ptr + offs, y)
+    tl.store(s_ptr + pid, s)
+
+
+def act_quant(
+    x: torch.Tensor, block_size: int = 128
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantizes the input tensor `x` using block-wise quantization.
+
+    Args:
+        x (torch.Tensor): The input tensor to be quantized. Must be contiguous and its last dimension size must be divisible by `block_size`.
+        block_size (int, optional): The size of the blocks to be used for quantization. Default is 128.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
+            - The quantized tensor with dtype `torch.float8_e4m3fn`.
+            - A tensor of scaling factors with dtype `torch.float32`.
+    """
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert (
+        x.size(-1) % block_size == 0
+    ), f"Last dimension size must be divisible by block_size (block_size={block_size})"
+    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    s = x.new_empty(*x.size()[:-1], x.size(-1) // block_size, dtype=torch.float32)
+    grid = lambda meta: (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)
+    act_quant_kernel[grid](x, y, s, BLOCK_SIZE=block_size, FP8_MAX=FP8_MAX)
+    return y, s
+
+
+def calculate_diff(m, dummy):
+    torch.manual_seed(SEED)
+
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    x = torch.arange(m, dtype=torch.float16, device='cuda').view(1, -1) / (m-1) + torch.arange(m, dtype=torch.float16, device='cuda').view(-1, 1) / (m-1)
+    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device='cuda')
+    xs_1 = torch.ones((triton.cdiv(m, 128), triton.cdiv(m, 128)), dtype=torch.float32, device='cuda')
+    
+    xq = x
+    wq = x
+
+    # x = torch.randn(m, m, dtype=torch.float16, device='cuda')
+
+    # xq, xs_0 = act_quant(x)
+    # wq, xs_1 = fp8_weight_block_wise_quant(x)
+
+    xq_fp8 = xq.to(torch.float8_e4m3fn)
+    wq_fp8 = wq.to(torch.float8_e4m3fn)
+
+    # print("x : ", x)
+    # print("xq : ", xq)
+    # print("wq : ", wq)
+
+    print("x.shape : ", x.shape)
+    print("xs_0.shape : ", xs_0.shape) 
+    print("xs_1.shape : ", xs_1.shape)   
+
+    o_torch_ref = (x @ x.T).cpu()
+    o_triton_fp8 = thunder_moun_gemm(xq.to(torch.float8_e4m3fn), wq.to(torch.float8_e4m3fn), xs_0, xs_1).cpu()
+
+    # print("troch ref : ", o_torch_ref)
+    # print("o_triton_fp8 : ", o_triton_fp8)
+    
+    # print("diff (torch): ", o_torch_ref - o_triton_fp8)
+
+    torch.testing.assert_close(
+        o_torch_ref, o_triton_fp8, rtol=2e-02, atol=1e-03
+    )
+
+    o_triton_fp8_ref = fp8_gemm_block_scaled(xq.to(torch.float8_e4m3fn), wq.to(torch.float8_e4m3fn), xs_0, xs_1).cpu()
+
+    # print("o_triton_fp8_ref : ", o_triton_fp8_ref)
+
+    # print("diff (triton): ", o_triton_fp8 - o_triton_fp8_ref)
+
+    # print("o_triton_fp8_ref : ", o_triton_fp8_ref)
+
+    print(f"✅ {m}x{m}x{m} thunder_moun_gemm")
+    torch.cuda.synchronize()
+
+    warmup = 25
+    iters = 100
+    for _ in range(warmup):
+        _ = (x @ x.T)
+    torch.cuda.synchronize()
+    
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    for _ in range(iters):
+        _ = (x @ x.T)
+    end_event.record()
+    torch.cuda.synchronize()
+    torch_time = (time.time() - start) / iters * 1000
+    torch_device_elapsed = start_event.elapsed_time(end_event) / iters
+
+    for _ in range(warmup):
+        _ = thunder_moun_gemm(xq_fp8, wq_fp8, xs_0, xs_1)
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    for _ in range(10):
+        o_triton_fp8 = thunder_moun_gemm(xq_fp8, wq_fp8, xs_0, xs_1)
+    end_event.record()
+    torch.cuda.synchronize()
+    triton_v2_time = (time.time() - start) / 10 * 1000
+    triton_v2_device_elapsed = start_event.elapsed_time(end_event) / iters
+
+    for _ in range(warmup):
+        _ = fp8_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1)
+    torch.cuda.synchronize()    
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    for _ in range(10):
+         o_triton_fp8_ref = fp8_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1)
+    end_event.record()
+    torch.cuda.synchronize()
+    triton_v1_time = (time.time() - start) / 10 * 1000
+    triton_v1_device_elapsed = start_event.elapsed_time(end_event) / iters
+
+    print(f"\nPerformance:")
+    print(f"PyTorch:            {torch_time:.3f} ms, device {torch_device_elapsed:.3f} ms")
+    print(f"Triton V1 kernel  : {triton_v1_time:.3f} ms, device {triton_v1_device_elapsed:.3f} ms")
+    print(f"Triton V2 kernel  : {triton_v2_time:.3f} ms, device {triton_v2_device_elapsed:.3f} ms")
+    print(f"Speedup (V1)      : {torch_time/triton_v1_time:.2f}x, {torch_device_elapsed / triton_v1_device_elapsed:.2f}x")
+    print(f"Speedup (V2)      : {torch_time/triton_v2_time:.2f}x, {torch_device_elapsed / triton_v2_device_elapsed:.2f}x")
+
+
+M = [2048, 4096, 8192]
+dummy = [1]
+
+configs = list(itertools.product(M, dummy))
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["m","dummy"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["torch", "triton_impl_v1", "triton_fp8_gemm_ref"],
+        line_names=["torch", "triton_muon_symm_gemm", "trition_fp8_gemm_ref"],
+        styles=[("red", "-"), ("blue", "-"), ("green","-")],
+        ylabel="Latency",
+        plot_name="muon-symm-gemm-performance",
+        args={},
+    )
+)
+def benchmark(m:int, dummy:int, provider) -> None:
+    torch.manual_seed(SEED)
+
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    # x = torch.arange(256, dtype=torch.float16, device='cuda').view(1, -1) / 255.0 + torch.arange(256, dtype=torch.float16, device='cuda').view(-1, 1) / 255.0
+    
+    x = torch.randn(m, m, dtype=torch.bfloat16, device='cuda')
+    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device='cuda')
+    xs_1 = torch.ones((triton.cdiv(m, 128), triton.cdiv(m, 128)), dtype=torch.float32, device='cuda')
+    
+    xq = x
+    wq = x
+
+    # x = torch.randn(m, m, dtype=torch.float16, device='cuda')
+
+    # xq, xs_0 = act_quant(x)
+    # wq, xs_1 = fp8_weight_block_wise_quant(x)
+
+    x_fp8 = xq.to(torch.float8_e4m3fn)
+    wq_fp8 = wq.to(torch.float8_e4m3fn)
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if provider == "torch":
+        fn = lambda : x @ x.T
+    elif provider == "triton_impl_v1":
+        fn = lambda : thunder_moun_gemm(x_fp8, wq_fp8, xs_0, xs_1)
+    elif provider == "triton_fp8_gemm_ref":
+        fn = lambda : fp8_gemm_block_scaled(x_fp8, wq_fp8, xs_0, xs_1)
+
+    # warm up
+    for _ in range(10):
+        fn()
+    torch.cuda.synchronize()
+
+    ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
+
+    return ms * 1000, min_ms * 1000, max_ms * 1000
+
+if __name__ == "__main__":
+    # Correctness check - simplified for CI
+    if IS_CI:
+        # Only test one configuration in CI
+        test_configs = [configs[0]]
+    else:
+        test_configs = configs
+
+    for cfg in test_configs:
+        print(f"cfg : {cfg}")
+        calculate_diff(*cfg)
+
+    print("\n" + "=" * 60)
+    print("Starting performance benchmark...")
+    benchmark.run(print_data=True)

--- a/benchmark/moun/bench_symm_gemm.py
+++ b/benchmark/moun/bench_symm_gemm.py
@@ -266,11 +266,11 @@ def calculate_diff(m, dummy):
 
     start = time.time()
     start_event.record()
-    for _ in range(10):
+    for _ in range(iters):
         o_triton_fp8 = thunder_moun_gemm(xq_fp8, wq_fp8, xs_0, xs_1)
     end_event.record()
     torch.cuda.synchronize()
-    triton_v2_time = (time.time() - start) / 10 * 1000
+    triton_v2_time = (time.time() - start) / iters * 1000
     triton_v2_device_elapsed = start_event.elapsed_time(end_event) / iters
 
     for _ in range(warmup):
@@ -282,11 +282,11 @@ def calculate_diff(m, dummy):
 
     start = time.time()
     start_event.record()
-    for _ in range(10):
+    for _ in range(iters):
          o_triton_fp8_ref = fp8_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1)
     end_event.record()
     torch.cuda.synchronize()
-    triton_v1_time = (time.time() - start) / 10 * 1000
+    triton_v1_time = (time.time() - start) / iters * 1000
     triton_v1_device_elapsed = start_event.elapsed_time(end_event) / iters
 
     print(f"\nPerformance:")

--- a/benchmark/moun/bench_symm_gemm.py
+++ b/benchmark/moun/bench_symm_gemm.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import time
 from typing import Any, Optional, Tuple
 
 import torch
@@ -7,11 +8,7 @@ import triton
 import triton.language as tl
 import triton.testing
 
-from jit_kernel.triton3_4.symm_gemm import thunder_moun_gemm, fp8_gemm_block_scaled
-
-from pdb import set_trace
-
-import time
+from jit_kernel.triton3_4.symm_gemm import fp8_gemm_block_scaled, thunder_moun_gemm
 
 SEED = 42
 
@@ -193,10 +190,14 @@ def calculate_diff(m, dummy):
     stream = torch.cuda.Stream()
     torch.cuda.set_stream(stream)
 
-    x = torch.arange(m, dtype=torch.float16, device='cuda').view(1, -1) / (m-1) + torch.arange(m, dtype=torch.float16, device='cuda').view(-1, 1) / (m-1)
-    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device='cuda')
-    xs_1 = torch.ones((triton.cdiv(m, 128), triton.cdiv(m, 128)), dtype=torch.float32, device='cuda')
-    
+    x = torch.arange(m, dtype=torch.float16, device="cuda").view(1, -1) / (
+        m - 1
+    ) + torch.arange(m, dtype=torch.float16, device="cuda").view(-1, 1) / (m - 1)
+    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device="cuda")
+    xs_1 = torch.ones(
+        (triton.cdiv(m, 128), triton.cdiv(m, 128)), dtype=torch.float32, device="cuda"
+    )
+
     xq = x
     wq = x
 
@@ -213,28 +214,42 @@ def calculate_diff(m, dummy):
     # print("wq : ", wq)
 
     print("x.shape : ", x.shape)
-    print("xs_0.shape : ", xs_0.shape) 
-    print("xs_1.shape : ", xs_1.shape)   
+    print("xs_0.shape : ", xs_0.shape)
+    print("xs_1.shape : ", xs_1.shape)
 
     o_torch_ref = (x @ x.T).cpu()
-    o_triton_fp8 = thunder_moun_gemm(xq.to(torch.float8_e4m3fn), wq.to(torch.float8_e4m3fn), xs_0, xs_1).cpu()
+    o_triton_fp8 = thunder_moun_gemm(
+        xq.to(torch.float8_e4m3fn), wq.to(torch.float8_e4m3fn), xs_0, xs_1
+    ).cpu()
 
     # print("troch ref : ", o_torch_ref)
     # print("o_triton_fp8 : ", o_triton_fp8)
-    
+
     # print("diff (torch): ", o_torch_ref - o_triton_fp8)
 
-    torch.testing.assert_close(
-        o_torch_ref, o_triton_fp8, rtol=2e-02, atol=1e-03
-    )
+    torch.testing.assert_close(o_torch_ref, o_triton_fp8, rtol=2e-02, atol=1e-03)
 
-    o_triton_fp8_ref = fp8_gemm_block_scaled(xq.to(torch.float8_e4m3fn), wq.to(torch.float8_e4m3fn), xs_0, xs_1).cpu()
+    o_triton_fp8_ref = fp8_gemm_block_scaled(
+        xq.to(torch.float8_e4m3fn), wq.to(torch.float8_e4m3fn), xs_0, xs_1
+    ).cpu()
 
     # print("o_triton_fp8_ref : ", o_triton_fp8_ref)
 
     # print("diff (triton): ", o_triton_fp8 - o_triton_fp8_ref)
 
-    # print("o_triton_fp8_ref : ", o_triton_fp8_ref)
+    torch.testing.assert_close(o_triton_fp8_ref, o_triton_fp8, rtol=2e-02, atol=1e-03)
+
+    o_triton_fp8_tril_ref = fp8_gemm_block_scaled(
+        xq.to(torch.float8_e4m3fn), wq.to(torch.float8_e4m3fn), xs_0, xs_1, is_symm=True
+    ).cpu()
+
+    # print("o_triton_fp8_ref (symm) : ", o_triton_fp8_tril_ref)
+
+    # print("diff (triton symm): ", o_triton_fp8 - o_triton_fp8_tril_ref)
+
+    torch.testing.assert_close(
+        o_triton_fp8_tril_ref, o_triton_fp8, rtol=2e-02, atol=1e-03
+    )
 
     print(f"✅ {m}x{m}x{m} thunder_moun_gemm")
     torch.cuda.synchronize()
@@ -242,20 +257,36 @@ def calculate_diff(m, dummy):
     warmup = 25
     iters = 100
     for _ in range(warmup):
-        _ = (x @ x.T)
+        _ = x @ x.T
     torch.cuda.synchronize()
-    
+
     start_event = torch.cuda.Event(enable_timing=True)
     end_event = torch.cuda.Event(enable_timing=True)
 
     start = time.time()
     start_event.record()
     for _ in range(iters):
-        _ = (x @ x.T)
+        _ = x @ x.T
     end_event.record()
     torch.cuda.synchronize()
     torch_time = (time.time() - start) / iters * 1000
     torch_device_elapsed = start_event.elapsed_time(end_event) / iters
+
+    for _ in range(warmup):
+        _ = fp8_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1, is_symm=True)
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    for _ in range(iters):
+        o_triton_fp8 = fp8_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1, is_symm=True)
+    end_event.record()
+    torch.cuda.synchronize()
+    triton_v3_time = (time.time() - start) / iters * 1000
+    triton_v3_device_elapsed = start_event.elapsed_time(end_event) / iters
 
     for _ in range(warmup):
         _ = thunder_moun_gemm(xq_fp8, wq_fp8, xs_0, xs_1)
@@ -275,7 +306,7 @@ def calculate_diff(m, dummy):
 
     for _ in range(warmup):
         _ = fp8_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1)
-    torch.cuda.synchronize()    
+    torch.cuda.synchronize()
 
     start_event = torch.cuda.Event(enable_timing=True)
     end_event = torch.cuda.Event(enable_timing=True)
@@ -283,18 +314,34 @@ def calculate_diff(m, dummy):
     start = time.time()
     start_event.record()
     for _ in range(iters):
-         o_triton_fp8_ref = fp8_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1)
+        o_triton_fp8_ref = fp8_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1)
     end_event.record()
     torch.cuda.synchronize()
     triton_v1_time = (time.time() - start) / iters * 1000
     triton_v1_device_elapsed = start_event.elapsed_time(end_event) / iters
 
     print(f"\nPerformance:")
-    print(f"PyTorch:            {torch_time:.3f} ms, device {torch_device_elapsed:.3f} ms")
-    print(f"Triton V1 kernel  : {triton_v1_time:.3f} ms, device {triton_v1_device_elapsed:.3f} ms")
-    print(f"Triton V2 kernel  : {triton_v2_time:.3f} ms, device {triton_v2_device_elapsed:.3f} ms")
-    print(f"Speedup (V1)      : {torch_time/triton_v1_time:.2f}x, {torch_device_elapsed / triton_v1_device_elapsed:.2f}x")
-    print(f"Speedup (V2)      : {torch_time/triton_v2_time:.2f}x, {torch_device_elapsed / triton_v2_device_elapsed:.2f}x")
+    print(
+        f"PyTorch                      : {torch_time:.3f} ms, device {torch_device_elapsed:.3f} ms"
+    )
+    print(
+        f"Triton V1 kernel             : {triton_v1_time:.3f} ms, device {triton_v1_device_elapsed:.3f} ms"
+    )
+    print(
+        f"Triton ThunderMoun kernel    : {triton_v2_time:.3f} ms, device {triton_v2_device_elapsed:.3f} ms"
+    )
+    print(
+        f"Triton V3 kernel             : {triton_v3_time:.3f} ms, device {triton_v3_device_elapsed:.3f} ms"
+    )
+    print(
+        f"Speedup (V1)                 : {torch_time/triton_v1_time:.2f}x, {torch_device_elapsed / triton_v1_device_elapsed:.2f}x"
+    )
+    print(
+        f"Speedup (ThunderMoun) kernel : {torch_time/triton_v2_time:.2f}x, {torch_device_elapsed / triton_v2_device_elapsed:.2f}x"
+    )
+    print(
+        f"Speedup (V3)                 : {torch_time/triton_v3_time:.2f}x, {torch_device_elapsed / triton_v3_device_elapsed:.2f}x"
+    )
 
 
 M = [2048, 4096, 8192]
@@ -302,36 +349,48 @@ dummy = [1]
 
 configs = list(itertools.product(M, dummy))
 
+
 @triton.testing.perf_report(
     triton.testing.Benchmark(
-        x_names=["m","dummy"],
+        x_names=["m", "dummy"],
         x_vals=configs,
         line_arg="provider",
-        line_vals=["torch", "triton_impl_v1", "triton_fp8_gemm_ref"],
-        line_names=["torch", "triton_muon_symm_gemm", "trition_fp8_gemm_ref"],
-        styles=[("red", "-"), ("blue", "-"), ("green","-")],
+        line_vals=[
+            "torch",
+            "triton_impl_v1",
+            "triton_fp8_gemm_ref",
+            "triton_fp8_gemm_tril_ref",
+        ],
+        line_names=[
+            "torch",
+            "triton_muon_symm_gemm",
+            "trition_fp8_gemm_ref",
+            "triton_fp8_gemm_tril_ref",
+        ],
+        styles=[("red", "-"), ("blue", "-"), ("green", "-"), ("orange", "-")],
         ylabel="Latency",
         plot_name="muon-symm-gemm-performance",
         args={},
     )
 )
-def benchmark(m:int, dummy:int, provider) -> None:
+def benchmark(m: int, dummy: int, provider) -> None:
     torch.manual_seed(SEED)
 
     stream = torch.cuda.Stream()
     torch.cuda.set_stream(stream)
 
     # x = torch.arange(256, dtype=torch.float16, device='cuda').view(1, -1) / 255.0 + torch.arange(256, dtype=torch.float16, device='cuda').view(-1, 1) / 255.0
-    
-    x = torch.randn(m, m, dtype=torch.bfloat16, device='cuda')
-    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device='cuda')
-    xs_1 = torch.ones((triton.cdiv(m, 128), triton.cdiv(m, 128)), dtype=torch.float32, device='cuda')
-    
+
+    x = torch.randn(m, m, dtype=torch.bfloat16, device="cuda")
+    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device="cuda")
+    xs_1 = torch.ones(
+        (triton.cdiv(m, 128), triton.cdiv(m, 128)), dtype=torch.float32, device="cuda"
+    )
+
     xq = x
     wq = x
 
-    # x = torch.randn(m, m, dtype=torch.float16, device='cuda')
-
+    # NOTE (yiakwy) : this can be computed asynchronously before Muon update
     # xq, xs_0 = act_quant(x)
     # wq, xs_1 = fp8_weight_block_wise_quant(x)
 
@@ -341,11 +400,13 @@ def benchmark(m:int, dummy:int, provider) -> None:
     quantiles = [0.5, 0.2, 0.8]
 
     if provider == "torch":
-        fn = lambda : x @ x.T
+        fn = lambda: x @ x.T
     elif provider == "triton_impl_v1":
-        fn = lambda : thunder_moun_gemm(x_fp8, wq_fp8, xs_0, xs_1)
+        fn = lambda: thunder_moun_gemm(x_fp8, wq_fp8, xs_0, xs_1)
     elif provider == "triton_fp8_gemm_ref":
-        fn = lambda : fp8_gemm_block_scaled(x_fp8, wq_fp8, xs_0, xs_1)
+        fn = lambda: fp8_gemm_block_scaled(x_fp8, wq_fp8, xs_0, xs_1)
+    elif provider == "triton_fp8_gemm_tril_ref":
+        fn = lambda: fp8_gemm_block_scaled(x_fp8, wq_fp8, xs_0, xs_1, is_symm=True)
 
     # warm up
     for _ in range(10):
@@ -355,6 +416,7 @@ def benchmark(m:int, dummy:int, provider) -> None:
     ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
 
     return ms * 1000, min_ms * 1000, max_ms * 1000
+
 
 if __name__ == "__main__":
     # Correctness check - simplified for CI

--- a/jit_kernel/triton3_4/symm_gemm.py
+++ b/jit_kernel/triton3_4/symm_gemm.py
@@ -1,0 +1,969 @@
+import ctypes
+
+from enum import Enum
+import hashlib
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+import itertools
+
+import pdb
+
+from packaging import version
+
+
+# using TVF FFI with triton
+USE_TVM_FFI=True
+
+tvm_ffi_modules = {
+    "fp8_gemm_block_scaled" : None,
+    "thunder_moun_gemm": None,
+}
+
+if USE_TVM_FFI:
+    import tvm_ffi
+    from jit_kernel.triton3_4.tvm_ffi_mod import generate_tvm_ffi_source
+
+def is_hopper():
+    return triton.runtime.driver.active.get_current_target().arch >= 90
+
+if is_hopper():
+    # nvidia sm90 does not support chiplet architecture, defaults to 1 xcd per gpu
+    NUM_XCDS = 1
+    OCP_FP8E4M3_MAX = 448.0
+
+    FP8_MAX = OCP_FP8E4M3_MAX
+
+    props = torch.cuda.get_device_properties(0)
+    SMs = props.multi_processor_count
+    NUM_CUs = SMs
+else:
+    raise Exception("Not supported yet!")
+
+
+class LoadBalanceStrategy(Enum):
+    UNDEFINE = -1
+    GAUSSIAN_FOLDING = 0
+
+# NOTE (yiakwy) : useful for multiple-die chiplet architecture :
+#   - Blackwell(2 dies), Rubin(2 dies),
+#   - Rubin Ultra(4 dies), MI300(4 dies), 
+#   - MI300X(8 dies)
+#
+# Make sure SPLIT-K blocks cooperatively work on the same die to maximize the cache hit re-usage
+@triton.jit
+def _remmap_pid(tile_id, tall_xcds, BLOCKS_PER_XCD, NUM_XCDS):
+    xcd = tile_id % NUM_XCDS
+    local_pid = tile_id // NUM_XCDS  # (local_id, xcd), strides : (NUM_XCDS, 1)
+    if xcd < tall_xcds:
+        tile_id = (
+            xcd * BLOCKS_PER_XCD + local_pid
+        )  # (xcd, local_id), strides : (BLOCKS_PER_XCD, 1)
+    else:
+        tile_id = (
+            tall_xcds * BLOCKS_PER_XCD
+            + (xcd - tall_xcds) * (BLOCKS_PER_XCD - 1)
+            + local_pid
+        )
+    return tile_id
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M):
+    if GROUP_SIZE_M == 1:
+        pid_n = tile_id % num_pid_n
+        pid_m = tile_id // num_pid_n
+
+        num_pid_in_group = num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+        group_id = tile_id // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + (
+            (tile_id % num_pid_in_group) % group_size_m
+        )
+        pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+@triton.jit
+def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair, 
+                           xq_ptr, wq_ptr, 
+                           xs_lhs_ptr, xs_rhs_ptr,
+                           o_ptr, 
+                           M, K, 
+                           stride_xq_m, stride_xq_k,
+                           stride_wq_n, stride_wq_k, 
+                           stride_xs_m, stride_xs_k,
+                           stride_ws_n, stride_ws_k,
+                           stride_o_m, stride_o_n,
+                           offs_k, start_ssteps, num_ssteps,
+                           BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K,
+                           SCALE_BLOCK_SIZE_N, 
+                           SCALE_BLOCK_SIZE_K, 
+                           SPLIT_K):
+    # step 1 : comptue data offset
+    offs_xq_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    # if pid_m_pair >= pid_n:
+    #     offs_xq_pair_m = (pid_m_pair * BLOCK_SIZE_M+ tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_xq_pair_m = (pid_m_pair * BLOCK_SIZE_M+ tl.arange(0, BLOCK_SIZE_M)) % M
+
+    if BLOCK_SIZE_M != BLOCK_SIZE_N or pid_m != pid_n:
+        offs_wq_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % M
+    else:
+        offs_wq_n = offs_xq_m
+
+    # (BLOCK_SIZE_M, BLOCK_SIZE_K)
+    xq_block_ptr = xq_ptr + (
+        offs_xq_m[:, None] * stride_xq_m + offs_k[None, :] * stride_xq_k
+    )
+    # if pid_m_pair >= pid_n:
+    #     xq_pair_block_ptr = xq_ptr + (
+    #         offs_xq_pair_m[:, None] * stride_xq_m + offs_k[None, :] * stride_xq_k
+    #     )
+    xq_pair_block_ptr = xq_ptr + (
+        offs_xq_pair_m[:, None] * stride_xq_m + offs_k[None, :] * stride_xq_k
+    )
+
+    # (BLOCK_SIZE_N, BLOCK_SIZE_K)
+    # if BLOCK_SIZE_M != BLOCK_SIZE_N or pid_m != pid_n:
+    #     wq_block_ptr = xq_ptr + (
+    #         offs_wq_n[:, None] * stride_wq_n + offs_k[None, :] * stride_wq_k
+    #     )
+    # else:
+    #     wq_block_ptr = xq_block_ptr
+    wq_block_ptr = wq_ptr + (
+        offs_wq_n[:, None] * stride_wq_n + offs_k[None, :] * stride_wq_k
+    )
+
+    # NOTE (yiakwy) : suppose BLOCK_SIZE_K <= SCALE_BLOCK_SIZE_K for simplicity
+    # (BLOCK_SIZE_M, )
+    xs_block_ptr = (
+        xs_lhs_ptr
+        + offs_xq_m * stride_xs_m
+        + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+    )
+    # if pid_m_pair >= pid_n:
+    #     xs_pair_block_ptr = (
+    #         xs_lhs_ptr
+    #         + offs_xq_pair_m * stride_xs_m
+    #         + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+    #     )
+    xs_pair_block_ptr = (
+        xs_lhs_ptr
+        + offs_xq_pair_m * stride_xs_m
+        + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+    )
+
+    offs_ws_n = offs_wq_n // SCALE_BLOCK_SIZE_N
+    # (BLOCK_SIZE_N, )
+    ws_block_ptr = (
+        xs_rhs_ptr
+        + offs_ws_n * stride_ws_n
+        + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+    )
+
+    # step 2: pre-load data for the first iteration, note that we load one more block of data and scales to hide the compute latency by IO
+    # for (pid_m, pid_n) = (m-1, 0), we load tile_x[m-1, k], tile_x[0, k]
+    xq = tl.load(
+        xq_block_ptr,
+        mask=offs_k[None, :] < K,
+        other=0.0,
+    )
+
+    xq_pair = xq
+    if pid_m_pair >= pid_n:
+        xq_pair = tl.load(
+            xq_pair_block_ptr,
+            mask=offs_k[None, :] < K,
+            other=0.0,
+        )
+
+    # if BLOCK_SIZE_M != BLOCK_SIZE_N or pid_m != pid_n:
+    #     wq = tl.load(
+    #         wq_block_ptr,
+    #         mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+    #         other=0.0,
+    #     )
+    # else:
+    #     wq = xq
+    wq = tl.load(
+        wq_block_ptr,
+        mask=offs_k[None, :] < K,
+        other=0.0,
+    )
+
+    xs = tl.load(xs_block_ptr)
+
+    xs_pair = xs
+    if pid_n <= pid_m_pair:
+        xs_pair = tl.load(xs_pair_block_ptr)
+
+    ws = tl.load(ws_block_ptr)
+
+    # NOTE (yiakwy) : Triton 3.4 hacks, allocate double buffer for the next block data and scales
+    xq_next = xq
+    wq_next = wq
+
+    xs_next = xs
+    ws_next = ws
+
+    xq_pair_next = xq_pair
+    xs_pair_next = xs_pair
+
+    last_ssteps = start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+    for k in tl.range(start_ssteps, start_ssteps + num_ssteps):
+        xq_k_step = BLOCK_SIZE_K * stride_xq_k
+        wq_k_step = BLOCK_SIZE_K * stride_wq_k
+
+        cur_ssteps = (k + 1) * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+        if k + 1 < num_ssteps:
+            xq_next = tl.load(
+                xq_block_ptr + xq_k_step,
+                mask=offs_k[None, :] < K - (k+1) * (BLOCK_SIZE_K),
+                other=0.0,
+            )
+
+            # if BLOCK_SIZE_M != BLOCK_SIZE_N or pid_m != pid_n:
+            #     wq_next = tl.load(
+            #         wq_block_ptr + wq_k_step,
+            #         mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+            #         other=0.0,
+            #     )
+            # else:
+            #     wq_next = xq_next
+            wq_next = tl.load(
+                wq_block_ptr + wq_k_step,
+                mask=offs_k[None, :] < K - (k+1) * (BLOCK_SIZE_K),
+                other=0.0,
+            )
+
+            if cur_ssteps > last_ssteps:
+                xs_next = tl.load(xs_block_ptr + stride_xs_k)
+                ws_next = tl.load(ws_block_ptr + stride_ws_k)
+
+        # if pid_m == 1 and pid_n == 0:
+        #     print("====== iteration k = ", k, " ======")
+        #     print(f"acc before {k} iters: {acc}, xq = {xq}, wq = {wq}, xs = {xs}, ws = {ws}")
+        
+        # (xq * xs) @ (bq * bs).T = { cij = xs_i*ws_j* sum_k (xq_ik * wq_kj) }
+        acc += tl.dot(xq, wq.trans(1, 0), input_precision="ieee") * (
+            xs[:, None] * ws[None, :]
+        )
+
+        # if pid_m == 1 and pid_n == 0:
+        #     print(f"acc after {k} iters : {acc}")
+        #     pass
+
+        if pid_m_pair >= pid_n:
+            if k + 1 < num_ssteps:
+                xq_pair_next = tl.load(
+                    xq_pair_block_ptr + xq_k_step,
+                    mask=offs_k[None, :] < K - (k+1) * (BLOCK_SIZE_K),
+                    other=0.0,
+                )
+                xs_pair_next = tl.load(xs_pair_block_ptr + stride_xs_k)
+            
+            acc_pair += tl.dot(xq_pair, wq.trans(1, 0), input_precision="ieee") * (
+                xs_pair[:, None] * ws[None, :]
+            )
+
+        # advance pointer
+        xq_block_ptr += xq_k_step
+        wq_block_ptr += wq_k_step
+
+        # advance scale pointer
+        if cur_ssteps > last_ssteps:
+            xs_block_ptr += stride_xs_k
+            ws_block_ptr += stride_ws_k
+
+        # move next data to current register
+        if k + 1 < num_ssteps:
+            xq = xq_next
+            wq = wq_next
+
+            if cur_ssteps > last_ssteps:
+                xs = xs_next
+                ws = ws_next
+
+        # processing pair group together to maximize the data re-use in cache
+        if pid_m_pair >= pid_n:
+            xq_pair_block_ptr += xq_k_step
+
+            if cur_ssteps > last_ssteps:
+                xs_pair_block_ptr += stride_xs_k
+
+            if k + 1 < num_ssteps:
+                xq_pair = xq_pair_next
+
+                if cur_ssteps > last_ssteps:
+                    xs_pair = xs_pair_next
+
+        last_ssteps = cur_ssteps
+
+    # print(f"(pid_m, pid_n) = {pid_m, pid_n} : ", acc)
+    if acc.dtype != o_ptr.type.element_ty:
+        _acc = acc.to(o_ptr.type.element_ty)
+    else:
+        _acc = acc
+    o_block_ptr = (
+        o_ptr + offs_xq_m[:, None] * stride_o_m + offs_wq_n[None, :] * stride_o_n
+    )
+    o_mask = (offs_xq_m[:, None] < M) & (offs_wq_n[None, :] < M)
+    if SPLIT_K == 1:
+        tl.store(o_block_ptr, _acc, mask=o_mask)
+    else:
+        tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+    # transpose copy for the symmetric tile
+    if pid_n < pid_m:
+        _acc = tl.trans(_acc, 1, 0)
+        o_block_ptr = (
+            o_ptr + offs_wq_n[:, None] * stride_o_m + offs_xq_m[None, :] * stride_o_n
+        )
+        o_mask = (offs_wq_n[:, None] < M) & (offs_xq_m[None, :] < M)
+        if SPLIT_K == 1:
+            tl.store(o_block_ptr, _acc, mask=o_mask)
+        else:
+            tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+    # deal with pair
+    # if pid_n <= pid_m_pair:
+    #     print(f"(pid_m_pair, pid_n) = {pid_m_pair, pid_n} : ", acc_pair)
+
+    if pid_n <= pid_m_pair:
+        if acc_pair.dtype != o_ptr.type.element_ty:
+            _acc = acc_pair.to(o_ptr.type.element_ty)
+        else:
+            _acc = acc_pair
+        o_pair_block_ptr = (
+            o_ptr + offs_xq_pair_m[:, None] * stride_o_m + offs_wq_n[None, :] * stride_o_n
+        )
+        o_mask_pair = (offs_xq_pair_m[:, None] < M) & (offs_wq_n[None, :] < M)
+        if SPLIT_K == 1:
+            tl.store(o_pair_block_ptr, _acc, mask=o_mask_pair)
+        else:
+            tl.atomic_add(o_pair_block_ptr, _acc, mask=o_mask_pair)
+
+        # transpose copy for the symmetric tile
+        if pid_n < pid_m_pair:
+            _acc = tl.trans(_acc, 1, 0)
+            o_pair_block_ptr = (
+                o_ptr + offs_wq_n[:, None] * stride_o_m + offs_xq_pair_m[None, :] * stride_o_n
+            )
+            o_mask_pair = (offs_wq_n[:, None] < M) & (offs_xq_pair_m[None, :] < M)
+            if SPLIT_K == 1:
+                tl.store(o_pair_block_ptr, _acc, mask=o_mask_pair)
+            else:
+                tl.atomic_add(o_pair_block_ptr, _acc, mask=o_mask_pair)
+
+
+# NOTE (yiakwy) : the implementation comes from flashFloat
+@triton.autotune(
+    configs=[
+        triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1}, num_stages=2, num_warps=8, maxnreg=384),
+    ],
+    key=('M', 'K'),
+    use_cuda_graph=False,
+)
+@triton.heuristics(
+    {
+        "NUM_PID_M": lambda args: triton.cdiv(args["M"] // 2, args["BLOCK_SIZE_M"]),
+        "SPLIT_K": lambda args: args.get("SPLIT_K", 1), # triton does not support NoC, see TLE (by Zhiyuan team) for replacement
+    }
+)
+@triton.jit
+def paired_symm_moun_mat_fp8_block_scaled_tuned_kernel(
+    xq_ptr, wq_ptr,
+    o_ptr,
+    M,
+    K,
+    stride_xq_m, stride_xq_k,
+    stride_o_m, stride_o_n,
+    xs_lhs_ptr,
+    xs_rhs_ptr,
+    stride_xs_lhs_m, stride_xs_lhs_k,
+    stride_xs_rhs_n, stride_xs_rhs_k,
+    SCALE_BLOCK_SIZE_K: tl.constexpr,
+    SCALE_BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    NUM_CUs: tl.constexpr,
+    NUM_PID_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    M_EVEN: tl.constexpr,
+):
+    pid_k = tl.program_id(axis=0)
+    pid_m = tl.program_id(axis=1)
+
+    num_pid_m = NUM_PID_M
+
+    if M_EVEN:
+        FULL_BLOCKS = num_pid_m * 2 - 1
+    else:
+        FULL_BLOCKS = num_pid_m * 2
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    num_ssteps = tl.cdiv(K, BLOCK_SIZE_K * SPLIT_K)
+
+    start_ssteps = pid_k * num_ssteps
+    offs_k += start_ssteps * BLOCK_SIZE_K
+
+    # acc cross SPLIT-K & mirror jobs
+    acc_dtype = tl.float32 # o_ptr.type.element_ty
+
+    # non-persistent version to group pid_m and FULL_BLOCKS - pid_m together
+    pid_m_pair = FULL_BLOCKS - pid_m
+    for pid_n in tl.range(0, pid_m_pair + 1):        
+        # group (GROUP_SIZE=2) pid_m and M - pid_m together
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+        acc_pair = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+
+        _symm_moun_mat_compute(
+            pid_m, pid_m_pair, pid_n, acc, acc_pair, 
+            xq_ptr, wq_ptr,
+            xs_lhs_ptr, xs_rhs_ptr,
+            o_ptr, 
+            M, K, 
+            stride_xq_m, stride_xq_k,
+            stride_xq_m, stride_xq_k,
+            stride_xs_lhs_m, stride_xs_lhs_k,
+            stride_xs_rhs_n, stride_xs_rhs_k,
+            stride_o_m, stride_o_n,
+            offs_k, start_ssteps, num_ssteps,
+            BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K,
+            SCALE_BLOCK_SIZE_N, SCALE_BLOCK_SIZE_K,
+            SPLIT_K
+        )
+
+
+# NOTE (yiakwy) : triton version implementation for tuning, not used in the final product
+def thunder_moun_gemm(
+        xq_lhs : torch.Tensor, 
+        xq_rhs : torch.Tensor, 
+        xs_0: torch.Tensor, 
+        xs_1: torch.Tensor, 
+        out: Optional[torch.Tensor] = None, 
+        online_quant: bool=False, 
+        SPLIT_K : int=1):
+    M, K = xq_lhs.shape
+    if out is None:
+        out = torch.zeros((M, M), device=xq_lhs.device, dtype=torch.float16)
+
+    # dipatch to kernel
+    grid = lambda META: (
+        SPLIT_K,
+        triton.cdiv(M // 2, META["BLOCK_SIZE_M"]),
+        1
+    )
+    kernel = paired_symm_moun_mat_fp8_block_scaled_tuned_kernel
+
+    if USE_TVM_FFI:
+        def get_stable_kernel_key(M, K, **kwargs):
+            key_str = f"M{M}_K{K}_" + "_".join(f"{k}{v}" for k, v in sorted(kwargs.items()))
+            return hashlib.md5(key_str.encode('utf-8')).hexdigest()
+        
+        key = get_stable_kernel_key(M, K, SPLIT_K=SPLIT_K)
+
+        if tvm_ffi_modules["thunder_moun_gemm"] is not None and tvm_ffi_modules["thunder_moun_gemm"].get(key, None) is not None:
+            module, grid = tvm_ffi_modules["thunder_moun_gemm"][key]
+            gx, gy, gz = grid
+
+        else:
+            # compile
+            compiled_kernel = kernel[grid](
+                xq_lhs,
+                xq_rhs,
+                out,
+                M, 
+                K,
+                xq_lhs.stride(0), xq_lhs.stride(1),
+                out.stride(0), out.stride(1),
+                xs_0,
+                xs_1,
+                xs_0.stride(0), xs_0.stride(1),
+                xs_1.stride(0), xs_1.stride(1),
+                SCALE_BLOCK_SIZE_K=128,
+                SCALE_BLOCK_SIZE_N=128,
+                NUM_XCDS=NUM_XCDS,
+                NUM_CUs=NUM_CUs,
+                SPLIT_K=SPLIT_K,
+                M_EVEN=M%2==0
+            )
+
+            # make triton cubins
+            cubin_bytes = compiled_kernel.kernel
+            # cubin_ptr = ctypes.cast(ctypes.c_char_p(cubin_bytes), ctypes.c_void_p).value
+
+            kernel_name = compiled_kernel.name
+            sources, constants = generate_tvm_ffi_source(compiled_kernel, kernel_name)
+
+            # register tvm ffi cubin launcher
+            module = tvm_ffi.cpp.load_inline("triton_loader", 
+                                            cuda_sources=sources,
+                                            extra_ldflags=["-lcudart", "-lcuda"],
+                                            embed_cubin={"triton_cubin": cubin_bytes})
+
+            gx = SPLIT_K
+            gy = triton.cdiv(M // 2, constants["BLOCK_SIZE_M"][1])
+            gz = 1
+
+            print(f"[{kernel_name}] gx={gx}, gy={gy}, gz={gz}")
+
+            # cache it
+            if tvm_ffi_modules["thunder_moun_gemm"] is None:
+                tvm_ffi_modules["thunder_moun_gemm"] = {}
+
+            tvm_ffi_modules["thunder_moun_gemm"][key] = (module, (gx, gy, gz))
+
+        # NOTE (yiakwy) : see cubin signature from generate_tvm_ffi_source, only leading dimensions (LD, i.e., **stride(0)** for row major) are kept as arguments, M, N, K are passed through constant memory, need to be consistent with the kernel definition
+        # NOTE (yiakwy) : for alignment safty we convert all integers to int32_t in the cubin launcher, need to be consistent with the kernel definition as well
+        module.paired_symm_moun_mat_fp8_block_scaled_tuned_kernel(
+            xq_lhs,
+            xq_rhs,
+            out,
+            int(M), int(K),
+            int(xq_lhs.stride(0)), int(xq_lhs.stride(1)),
+            int(out.stride(0)), int(out.stride(1)),
+            xs_0,
+            xs_1,
+            int(xs_0.stride(0)), int(xs_0.stride(1)),
+            int(xs_1.stride(0)), int(xs_1.stride(1)),
+            int(gx), int(gy), int(gz)
+        )
+        return out
+    else:
+        kernel[grid](
+            xq_lhs,
+            xq_rhs,
+            out,
+            M, 
+            K,
+            xq_lhs.stride(0), xq_lhs.stride(1),
+            out.stride(0), out.stride(1),
+            xs_0,
+            xs_1,
+            xs_0.stride(0), xs_0.stride(1),
+            xs_1.stride(0), xs_1.stride(1),
+            SCALE_BLOCK_SIZE_K=128,
+            SCALE_BLOCK_SIZE_N=128,
+            NUM_XCDS=NUM_XCDS,
+            NUM_CUs=NUM_CUs,
+            SPLIT_K=SPLIT_K,
+            M_EVEN=M%2==0
+        )
+
+    return out
+
+
+# NOTE (yiakwy) : triton normal block scale mm kernel for performance comparison, not used in the final product
+def get_pack_size(
+        pack_int8=False,
+        pack_int16=False,
+        pack_int32=False,
+):
+    if pack_int8:
+        return 8
+    if pack_int16:
+        return 16
+    if pack_int32:
+        return 32
+    return 1
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 16, 'NUM_STAGES': 3}, num_stages=3, num_warps=16, maxnreg=384),
+        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 16, 'NUM_STAGES': 3}, num_stages=3, num_warps=8, maxnreg=384),
+    ],
+    key=('M', 'N', 'K'),
+    use_cuda_graph=True,
+)
+@triton.heuristics(
+    {
+        "GRID_MN": lambda args: triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+            * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+        "BLOCKS_PER_XCD": lambda args: triton.cdiv(
+            triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+            * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+            NUM_XCDS,
+        ),
+        "NUM_PID_M": lambda args: triton.cdiv(args["M"], args["BLOCK_SIZE_M"]),
+        "NUM_PID_N": lambda args: triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+        "SPLIT_K":   lambda args: 1, # triton does not support NoC, SPLIT_K usually won't work unless the K dimension is extremely large
+        "w1a16": lambda args: args.get("pack_int8", False) or args.get("pack_int16", False) or args.get("pack_int32", False), # need to be consistent with the data layout of wq
+        "packed_size": lambda args: get_pack_size(
+            pack_int8 =args.get("pack_int8" , False),
+            pack_int16=args.get("pack_int16", False),
+            pack_int32=args.get("pack_int32", False)
+        ),
+        "_is_hopper": lambda args: is_hopper(),
+    }
+)
+@triton.jit
+def fp8_streamk_gemm_block_scaled_tuned_kernel(
+    xq_ptr,
+    wq_ptr,
+    o_ptr,
+    M,
+    N,
+    K,
+    stride_xq_m,
+    stride_xq_k,
+    stride_wq_n,
+    stride_wq_k,
+    stride_o_m,
+    stride_o_n,
+    xs_ptr,
+    ws_ptr,
+    stride_xs_m,
+    stride_xs_k,
+    stride_ws_n,
+    stride_ws_k,
+    SCALE_BLOCK_SIZE_K: tl.constexpr,
+    SCALE_BLOCK_SIZE_N: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_CUs: tl.constexpr,
+    GRID_MN: tl.constexpr,
+    BLOCKS_PER_XCD: tl.constexpr,
+    NUM_PID_M: tl.constexpr,
+    NUM_PID_N: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    w1a16: tl.constexpr,
+    packed_size: tl.constexpr,
+    use_w1a16_as_fp8: tl.constexpr,
+    use_w1a8: tl.constexpr,
+    _is_hopper: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+
+    num_pid_m = NUM_PID_M
+    num_pid_n = NUM_PID_N
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    if w1a16:
+        offs_k_packed = tl.arange(0, BLOCK_SIZE_K // packed_size)
+
+    num_ssteps = tl.cdiv(K, BLOCK_SIZE_K * SPLIT_K)
+
+    for tile_id_0 in tl.range(pid, GRID_MN * SPLIT_K, NUM_CUs):
+        tile_id = tile_id_0 % GRID_MN
+        pid_k = tile_id_0 // GRID_MN
+
+        start_ssteps = pid_k * num_ssteps
+        offs_k += start_ssteps * BLOCK_SIZE_K
+        if w1a16:
+            offs_k_packed += start_ssteps * BLOCK_SIZE_K //  packed_size
+
+        pid_m, pid_n = _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+        offs_xq_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+        offs_wq_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+
+        # (BLOCK_SIZE_M, BLOCK_SIZE_K)
+        xq_block_ptr = xq_ptr + (
+            offs_xq_m[:, None] * stride_xq_m + offs_k[None, :] * stride_xq_k
+        )
+        if w1a16:
+            # bits to unpack
+            unpack_offs = tl.arange(0, packed_size).to(wq_ptr.type.element_ty)
+
+            # (BLOCK_SIZE_N, BLOCK_SIZE_K // packed_size)
+            wq_block_ptr = wq_ptr + (
+                offs_wq_n[:, None] * stride_wq_n + offs_k_packed[None, :] * stride_wq_k
+            )
+
+        else:
+            # (BLOCK_SIZE_N, BLOCK_SIZE_K)
+            wq_block_ptr = wq_ptr + (
+                offs_wq_n[:, None] * stride_wq_n + offs_k[None, :] * stride_wq_k
+            )
+
+            # (BLOCK_SIZE_M, )
+            xs_block_ptr = (
+                xs_ptr
+                + offs_xq_m * stride_xs_m
+                + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            )
+
+            offs_ws_n = offs_wq_n // SCALE_BLOCK_SIZE_N
+            # (BLOCK_SIZE_N, )
+            ws_block_ptr = (
+                ws_ptr
+                + offs_ws_n * stride_ws_n
+                + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            )
+
+        acc_dtype = tl.float16 # tl.float32
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+
+        if not w1a16:
+            xs_next = tl.load(xs_block_ptr)
+            ws_next = tl.load(ws_block_ptr)
+
+        # NOTE (yiakwy) : different from 
+        last_ssteps = start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+        for k in tl.range(start_ssteps, start_ssteps + num_ssteps, num_stages=NUM_STAGES):
+            xq = tl.load(
+                xq_block_ptr,
+                mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+                other=0.0,
+            )
+
+            if w1a16:
+                wq = tl.load(
+                    wq_block_ptr,
+                    mask=offs_k_packed[None, :] < K // packed_size - k * (BLOCK_SIZE_K // packed_size),
+                    other=0.0,
+                )
+
+                # NOTE(yiakwy) : w1a16, unpack (BLOCK_SIZE_N, BLOCK_SIZE_K // pack_size) to (BLOCK_SIZE_N, pack_size, BLOCK_SIZE_K // pack_size)
+                wq = wq[:, :, None]
+
+                wq = tl.inline_asm_elementwise(
+                    asm="bfe.u32 $0, $1, $2, 1;",
+                    constraints="=r,r,r",   
+                    args=[wq, unpack_offs[None, None, :]],
+                    dtype=wq_ptr.type.element_ty,
+                    is_pure=True,
+                    pack=1,
+                )
+
+                wq = wq.reshape((BLOCK_SIZE_N, BLOCK_SIZE_K))
+                wq = (wq * 2 - 1)
+                wq = wq.to(tl.float16)
+
+                if use_w1a16_as_fp8:
+                    wq = wq.to(tl.float8e4nv)
+                    xq = xq.to(tl.float8e4nv)
+                elif use_w1a8:
+                    wq = wq.to(tl.float8e4nv)
+
+            else:
+                wq = tl.load(
+                    wq_block_ptr,
+                    mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+                    other=0.0,
+                )
+
+                if wq.dtype == tl.int8 or wq.dtype == tl.int16:
+                    wq = wq.to(tl.float16)
+
+                    if use_w1a16_as_fp8:
+                        wq = wq.to(tl.float8e4nv)
+                        xq = xq.to(tl.float8e4nv)
+                    elif use_w1a8:
+                        wq = wq.to(tl.float8e4nv)
+
+            ws = ws_next
+            xs = xs_next
+
+            cur_ssteps = (k + 1) * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            if cur_ssteps > last_ssteps and (k + 1) < num_ssteps:
+                xs_next = tl.load(xs_block_ptr + stride_xs_k)
+                ws_next = tl.load(ws_block_ptr + stride_ws_k)
+
+            if w1a16:
+                acc = tl.dot(xq, wq.trans(1, 0), acc=acc, out_dtype=acc_dtype)
+            else:
+                if False: # _is_hopper:
+                    # acc = tl.dot_scaled(xq, xs.reshape(BLOCK_SIZE_M, 1), "e4m3", wq.trans(1, 0), ws.reshape(BLOCK_SIZE_N, 1), "e4m3", acc, out_dtype=acc_dtype)
+                    acc = tl.dot(xq * xs[:, None], (wq * ws[:, None]).trans(1, 0), acc=acc, input_precision="ieee", out_dtype=acc_dtype)
+                else:
+                    # (xq * xs) @ (bq * bs).T = { cij = xs_i*ws_j* sum_k (xq_ik * wq_kj) }
+                    acc += tl.dot(xq, wq.trans(1, 0), input_precision="ieee", out_dtype=acc_dtype) * (
+                        (xs[:, None] * ws[None, :]).to(acc_dtype)
+                    )
+
+            xq_block_ptr += BLOCK_SIZE_K * stride_xq_k
+            if w1a16:
+                wq_block_ptr += BLOCK_SIZE_K // packed_size * stride_wq_k
+            else:
+                wq_block_ptr += BLOCK_SIZE_K * stride_wq_k
+
+            if cur_ssteps > last_ssteps and (k + 1) < num_ssteps:
+                xs_block_ptr += stride_xs_k
+                ws_block_ptr += stride_ws_k
+
+            last_ssteps = cur_ssteps
+
+        o_block_ptr = (
+            o_ptr + offs_xq_m[:, None] * stride_o_m + offs_wq_n[None, :] * stride_o_n
+        )
+        o_mask = (offs_xq_m[:, None] < M) & (offs_wq_n[None, :] < N)
+
+        if o_ptr.type.element_ty != acc.dtype:
+            _acc = acc.to(o_ptr.type.element_ty)
+        else:
+            _acc = acc
+        if SPLIT_K == 1:
+            tl.store(o_block_ptr, _acc, mask=o_mask)
+        else:
+            tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+
+def fp8_gemm_block_scaled(
+    xq: torch.Tensor,
+    wq: torch.Tensor,
+    xs: torch.Tensor,
+    ws: torch.Tensor,
+    o: Optional[torch.Tensor] = None,
+    SCALE_BLOCK_SIZE_N=128,
+    SCALE_BLOCK_SIZE_K=128,
+    check_input_shape=False,
+):
+    if check_input_shape:
+        assert xq.dim() >= 2, "xq must be >= 2 dims"
+        assert wq.dim() >= 2, "wq must be >= 2 dims"
+
+        if xq.dim() > 2:
+            xq_flatten = xq.flatten(start_dim=1)
+            wq_flatten = wq.flatten(start_dim=1)
+
+            xq = xq_flatten
+            wq = wq_flatten
+
+        assert xq.shape[1] == wq.shape[1], "the shapes of xq and wq are incompatible!"
+
+    M, K = xq.shape
+    N = wq.shape[0]
+
+    if o is None:
+        o = torch.zeros((M, N), device=xq.device, dtype=torch.float16)
+
+    # dispatch to kernel
+    grid = lambda META: (
+        min(
+            NUM_CUs,
+            triton.cdiv(M, META["BLOCK_SIZE_M"])
+            * triton.cdiv(N, META["BLOCK_SIZE_N"])
+            * META["SPLIT_K"],
+        ),
+    )
+    kernel = fp8_streamk_gemm_block_scaled_tuned_kernel
+
+    if USE_TVM_FFI:
+        global tvm_ffi_modules
+
+        def get_stable_kernel_key(M, N, K, **kwargs):
+            key_str = f"M{M}_N{N}_K{K}_" + "_".join(f"{k}{v}" for k, v in sorted(kwargs.items()))
+            return hashlib.md5(key_str.encode('utf-8')).hexdigest()
+        
+        key = get_stable_kernel_key(M, N, K, SPLIT_K=1)
+
+        if tvm_ffi_modules["fp8_gemm_block_scaled"] is not None and tvm_ffi_modules["fp8_gemm_block_scaled"].get(key, None) is not None:
+            module, grid = tvm_ffi_modules["fp8_gemm_block_scaled"][key]
+            gx, gy, gz = grid
+
+        else:
+            # compile
+            compiled_kernel = kernel[grid](
+                xq,
+                wq,
+                o,
+                M,
+                N,
+                K,
+                xq.stride(0), xq.stride(1),
+                wq.stride(0), wq.stride(1),
+                o.stride(0), o.stride(1),
+                xs,
+                ws,
+                xs.stride(0), xs.stride(1),
+                ws.stride(0), ws.stride(1),
+                SCALE_BLOCK_SIZE_N=SCALE_BLOCK_SIZE_N,
+                SCALE_BLOCK_SIZE_K=SCALE_BLOCK_SIZE_K,
+                NUM_XCDS=NUM_XCDS,
+                NUM_CUs=NUM_CUs,
+                use_w1a16_as_fp8=False,
+                use_w1a8=False,
+            )
+
+            # make triton cubins
+            cubin_bytes = compiled_kernel.kernel
+            # cubin_ptr = ctypes.cast(ctypes.c_char_p(cubin_bytes), ctypes.c_void_p).value
+            
+            kernel_name = compiled_kernel.name
+            sources, constants = generate_tvm_ffi_source(compiled_kernel, kernel_name)
+
+            # register tvm ffi cubin launcher
+            module = tvm_ffi.cpp.load_inline("triton_loader", 
+                                            cuda_sources=sources,
+                                            extra_ldflags=["-lcudart", "-lcuda"],
+                                            embed_cubin={"triton_cubin": cubin_bytes})
+
+            gx = min(
+                NUM_CUs,
+                triton.cdiv(M, constants["BLOCK_SIZE_M"][1])
+                * triton.cdiv(N, constants["BLOCK_SIZE_N"][1])
+                * constants["BLOCK_SIZE_K"][1],
+            )
+            gy = gz = 1
+
+            print(f"[{kernel_name}] gx={gx}, gy={gy}, gz={gz}")
+
+            # cache it
+            if tvm_ffi_modules["fp8_gemm_block_scaled"] is None:
+                tvm_ffi_modules["fp8_gemm_block_scaled"] = {}
+
+            tvm_ffi_modules["fp8_gemm_block_scaled"][key] = (module, (gx, gy, gz))
+
+        # for name, tensor in [("xq", xq), ("wq", wq), ("o", o), ("xs", xs), ("ws", ws)]:
+        #     addr = tensor.data_ptr()
+        #     assert addr % 16 == 0, f"{name} address {addr} is not 16-byte aligned! This causes misaligned address error."
+
+        # NOTE (yiakwy) : see cubin signature from generate_tvm_ffi_source, only leading dimensions (LD, i.e., **stride(0)** for row major) are kept as arguments, M, N, K are passed through constant memory, need to be consistent with the kernel definition
+        module.fp8_streamk_gemm_block_scaled_tuned_kernel(
+            # cubin_ptr,
+            xq,
+            wq,
+            o,
+            int(M), int(N), int(K),
+            int(xq.stride(0)), int(xq.stride(1)), 
+            int(wq.stride(0)), int(wq.stride(1)), 
+            int(o.stride(0)), int(o.stride(1)),
+            xs,
+            ws,
+            int(xs.stride(0)), int(xs.stride(1)), 
+            int(ws.stride(0)), int(ws.stride(1)),
+            int(gx), int(gy), int(gz)
+        )
+        return o
+    else:
+        kernel[grid](
+            xq,
+            wq,
+            o,
+            M,
+            N,
+            K,
+            xq.stride(0), xq.stride(1),
+            wq.stride(0), wq.stride(1),
+            o.stride(0), o.stride(1),
+            xs,
+            ws,
+            xs.stride(0), xs.stride(1),
+            ws.stride(0), ws.stride(1),
+            SCALE_BLOCK_SIZE_N=SCALE_BLOCK_SIZE_N,
+            SCALE_BLOCK_SIZE_K=SCALE_BLOCK_SIZE_K,
+            NUM_XCDS=NUM_XCDS,
+            NUM_CUs=NUM_CUs,
+            use_w1a16_as_fp8=False,
+            use_w1a8=False,
+        )
+
+    return o

--- a/jit_kernel/triton3_4/symm_gemm.py
+++ b/jit_kernel/triton3_4/symm_gemm.py
@@ -1,34 +1,32 @@
 import ctypes
-
-from enum import Enum
 import hashlib
+import itertools
+from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import triton
 import triton.language as tl
-
-import itertools
-
-import pdb
-
 from packaging import version
 
-
 # using TVF FFI with triton
-USE_TVM_FFI=True
+USE_TVM_FFI = True
 
 tvm_ffi_modules = {
-    "fp8_gemm_block_scaled" : None,
+    "fp8_gemm_block_scaled": None,
     "thunder_moun_gemm": None,
 }
 
+
 if USE_TVM_FFI:
     import tvm_ffi
+
     from jit_kernel.triton3_4.tvm_ffi_mod import generate_tvm_ffi_source
+
 
 def is_hopper():
     return triton.runtime.driver.active.get_current_target().arch >= 90
+
 
 if is_hopper():
     # nvidia sm90 does not support chiplet architecture, defaults to 1 xcd per gpu
@@ -48,9 +46,10 @@ class LoadBalanceStrategy(Enum):
     UNDEFINE = -1
     GAUSSIAN_FOLDING = 0
 
+
 # NOTE (yiakwy) : useful for multiple-die chiplet architecture :
 #   - Blackwell(2 dies), Rubin(2 dies),
-#   - Rubin Ultra(4 dies), MI300(4 dies), 
+#   - Rubin Ultra(4 dies), MI300(4 dies),
 #   - MI300X(8 dies)
 #
 # Make sure SPLIT-K blocks cooperatively work on the same die to maximize the cache hit re-usage
@@ -71,6 +70,17 @@ def _remmap_pid(tile_id, tall_xcds, BLOCKS_PER_XCD, NUM_XCDS):
     return tile_id
 
 
+# see our paper
+# pid = pid_m * (pid_m + 1) / 2 + pid_n
+# pid_m*2 + pid_m - 2*pid - pid_n = 0
+@triton.jit
+def linear_to_tril(pid):
+    # row = floor((sqrt(8*pid + 1) - 1) / 2)
+    row = tl.floor((tl.math.sqrt(8.0 * pid + 1.0) - 1.0) / 2.0).to(tl.int32)
+    col = pid - (row * (row + 1)) // 2
+    return row, col
+
+
 @triton.jit
 def _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M):
     if GROUP_SIZE_M == 1:
@@ -84,34 +94,50 @@ def _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M):
         group_id = tile_id // num_pid_in_group
         first_pid_m = group_id * GROUP_SIZE_M
         group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-        pid_m = first_pid_m + (
-            (tile_id % num_pid_in_group) % group_size_m
-        )
+        pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
         pid_n = (tile_id % num_pid_in_group) // group_size_m
     return pid_m, pid_n
 
 
 @triton.jit
-def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair, 
-                           xq_ptr, wq_ptr, 
-                           xs_lhs_ptr, xs_rhs_ptr,
-                           o_ptr, 
-                           M, K, 
-                           stride_xq_m, stride_xq_k,
-                           stride_wq_n, stride_wq_k, 
-                           stride_xs_m, stride_xs_k,
-                           stride_ws_n, stride_ws_k,
-                           stride_o_m, stride_o_n,
-                           offs_k, start_ssteps, num_ssteps,
-                           BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K,
-                           SCALE_BLOCK_SIZE_N, 
-                           SCALE_BLOCK_SIZE_K, 
-                           SPLIT_K):
+def _symm_moun_mat_compute(
+    pid_m_pair,
+    pid_m,
+    pid_n,
+    acc,
+    acc_pair,
+    xq_ptr,
+    wq_ptr,
+    xs_lhs_ptr,
+    xs_rhs_ptr,
+    o_ptr,
+    M,
+    K,
+    stride_xq_m,
+    stride_xq_k,
+    stride_wq_n,
+    stride_wq_k,
+    stride_xs_m,
+    stride_xs_k,
+    stride_ws_n,
+    stride_ws_k,
+    stride_o_m,
+    stride_o_n,
+    offs_k,
+    start_ssteps,
+    num_ssteps,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    SCALE_BLOCK_SIZE_N,
+    SCALE_BLOCK_SIZE_K,
+    SPLIT_K,
+):
     # step 1 : comptue data offset
     offs_xq_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
     # if pid_m_pair >= pid_n:
     #     offs_xq_pair_m = (pid_m_pair * BLOCK_SIZE_M+ tl.arange(0, BLOCK_SIZE_M)) % M
-    offs_xq_pair_m = (pid_m_pair * BLOCK_SIZE_M+ tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_xq_pair_m = (pid_m_pair * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
 
     if BLOCK_SIZE_M != BLOCK_SIZE_N or pid_m != pid_n:
         offs_wq_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % M
@@ -217,15 +243,16 @@ def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair,
     xs_pair_next = xs_pair
 
     last_ssteps = start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
-    for k in tl.range(start_ssteps, start_ssteps + num_ssteps):
+    end_ssteps = start_ssteps + num_ssteps
+    for k in tl.range(start_ssteps, end_ssteps):
         xq_k_step = BLOCK_SIZE_K * stride_xq_k
         wq_k_step = BLOCK_SIZE_K * stride_wq_k
 
         cur_ssteps = (k + 1) * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
-        if k + 1 < num_ssteps:
+        if k + 1 < end_ssteps:
             xq_next = tl.load(
                 xq_block_ptr + xq_k_step,
-                mask=offs_k[None, :] < K - (k+1) * (BLOCK_SIZE_K),
+                mask=offs_k[None, :] < K - (k + 1) * (BLOCK_SIZE_K),
                 other=0.0,
             )
 
@@ -239,7 +266,7 @@ def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair,
             #     wq_next = xq_next
             wq_next = tl.load(
                 wq_block_ptr + wq_k_step,
-                mask=offs_k[None, :] < K - (k+1) * (BLOCK_SIZE_K),
+                mask=offs_k[None, :] < K - (k + 1) * (BLOCK_SIZE_K),
                 other=0.0,
             )
 
@@ -250,7 +277,7 @@ def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair,
         # if pid_m == 1 and pid_n == 0:
         #     print("====== iteration k = ", k, " ======")
         #     print(f"acc before {k} iters: {acc}, xq = {xq}, wq = {wq}, xs = {xs}, ws = {ws}")
-        
+
         # (xq * xs) @ (bq * bs).T = { cij = xs_i*ws_j* sum_k (xq_ik * wq_kj) }
         acc += tl.dot(xq, wq.trans(1, 0), input_precision="ieee") * (
             xs[:, None] * ws[None, :]
@@ -261,14 +288,14 @@ def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair,
         #     pass
 
         if pid_m_pair >= pid_n:
-            if k + 1 < num_ssteps:
+            if k + 1 < end_ssteps:
                 xq_pair_next = tl.load(
                     xq_pair_block_ptr + xq_k_step,
-                    mask=offs_k[None, :] < K - (k+1) * (BLOCK_SIZE_K),
+                    mask=offs_k[None, :] < K - (k + 1) * (BLOCK_SIZE_K),
                     other=0.0,
                 )
                 xs_pair_next = tl.load(xs_pair_block_ptr + stride_xs_k)
-            
+
             acc_pair += tl.dot(xq_pair, wq.trans(1, 0), input_precision="ieee") * (
                 xs_pair[:, None] * ws[None, :]
             )
@@ -283,7 +310,7 @@ def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair,
             ws_block_ptr += stride_ws_k
 
         # move next data to current register
-        if k + 1 < num_ssteps:
+        if k + 1 < end_ssteps:
             xq = xq_next
             wq = wq_next
 
@@ -298,7 +325,7 @@ def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair,
             if cur_ssteps > last_ssteps:
                 xs_pair_block_ptr += stride_xs_k
 
-            if k + 1 < num_ssteps:
+            if k + 1 < end_ssteps:
                 xq_pair = xq_pair_next
 
                 if cur_ssteps > last_ssteps:
@@ -342,7 +369,9 @@ def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair,
         else:
             _acc = acc_pair
         o_pair_block_ptr = (
-            o_ptr + offs_xq_pair_m[:, None] * stride_o_m + offs_wq_n[None, :] * stride_o_n
+            o_ptr
+            + offs_xq_pair_m[:, None] * stride_o_m
+            + offs_wq_n[None, :] * stride_o_n
         )
         o_mask_pair = (offs_xq_pair_m[:, None] < M) & (offs_wq_n[None, :] < M)
         if SPLIT_K == 1:
@@ -354,7 +383,9 @@ def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair,
         if pid_n < pid_m_pair:
             _acc = tl.trans(_acc, 1, 0)
             o_pair_block_ptr = (
-                o_ptr + offs_wq_n[:, None] * stride_o_m + offs_xq_pair_m[None, :] * stride_o_n
+                o_ptr
+                + offs_wq_n[:, None] * stride_o_m
+                + offs_xq_pair_m[None, :] * stride_o_n
             )
             o_mask_pair = (offs_wq_n[:, None] < M) & (offs_xq_pair_m[None, :] < M)
             if SPLIT_K == 1:
@@ -366,29 +397,46 @@ def _symm_moun_mat_compute(pid_m_pair, pid_m, pid_n, acc, acc_pair,
 # NOTE (yiakwy) : the implementation comes from flashFloat
 @triton.autotune(
     configs=[
-        triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1}, num_stages=2, num_warps=8, maxnreg=384),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 1,
+            },
+            num_stages=2,
+            num_warps=8,
+            maxnreg=384,
+        ),
     ],
-    key=('M', 'K'),
-    use_cuda_graph=False,
+    key=("M", "K"),
+    use_cuda_graph=True,
 )
 @triton.heuristics(
     {
         "NUM_PID_M": lambda args: triton.cdiv(args["M"] // 2, args["BLOCK_SIZE_M"]),
-        "SPLIT_K": lambda args: args.get("SPLIT_K", 1), # triton does not support NoC, see TLE (by Zhiyuan team) for replacement
+        "SPLIT_K": lambda args: args.get(
+            "SPLIT_K", 1
+        ),  # triton does not support NoC, see TLE (by Zhiyuan team) for replacement
     }
 )
 @triton.jit
 def paired_symm_moun_mat_fp8_block_scaled_tuned_kernel(
-    xq_ptr, wq_ptr,
+    xq_ptr,
+    wq_ptr,
     o_ptr,
     M,
     K,
-    stride_xq_m, stride_xq_k,
-    stride_o_m, stride_o_n,
+    stride_xq_m,
+    stride_xq_k,
+    stride_o_m,
+    stride_o_n,
     xs_lhs_ptr,
     xs_rhs_ptr,
-    stride_xs_lhs_m, stride_xs_lhs_k,
-    stride_xs_rhs_n, stride_xs_rhs_k,
+    stride_xs_lhs_m,
+    stride_xs_lhs_k,
+    stride_xs_rhs_n,
+    stride_xs_rhs_k,
     SCALE_BLOCK_SIZE_K: tl.constexpr,
     SCALE_BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
@@ -419,62 +467,82 @@ def paired_symm_moun_mat_fp8_block_scaled_tuned_kernel(
     offs_k += start_ssteps * BLOCK_SIZE_K
 
     # acc cross SPLIT-K & mirror jobs
-    acc_dtype = tl.float32 # o_ptr.type.element_ty
+    acc_dtype = tl.float32  # o_ptr.type.element_ty
 
     # non-persistent version to group pid_m and FULL_BLOCKS - pid_m together
     pid_m_pair = FULL_BLOCKS - pid_m
-    for pid_n in tl.range(0, pid_m_pair + 1):        
+    for pid_n in tl.range(0, pid_m_pair + 1):
         # group (GROUP_SIZE=2) pid_m and M - pid_m together
         acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
         acc_pair = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
 
         _symm_moun_mat_compute(
-            pid_m, pid_m_pair, pid_n, acc, acc_pair, 
-            xq_ptr, wq_ptr,
-            xs_lhs_ptr, xs_rhs_ptr,
-            o_ptr, 
-            M, K, 
-            stride_xq_m, stride_xq_k,
-            stride_xq_m, stride_xq_k,
-            stride_xs_lhs_m, stride_xs_lhs_k,
-            stride_xs_rhs_n, stride_xs_rhs_k,
-            stride_o_m, stride_o_n,
-            offs_k, start_ssteps, num_ssteps,
-            BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K,
-            SCALE_BLOCK_SIZE_N, SCALE_BLOCK_SIZE_K,
-            SPLIT_K
+            pid_m,
+            pid_m_pair,
+            pid_n,
+            acc,
+            acc_pair,
+            xq_ptr,
+            wq_ptr,
+            xs_lhs_ptr,
+            xs_rhs_ptr,
+            o_ptr,
+            M,
+            K,
+            stride_xq_m,
+            stride_xq_k,
+            stride_xq_m,
+            stride_xq_k,
+            stride_xs_lhs_m,
+            stride_xs_lhs_k,
+            stride_xs_rhs_n,
+            stride_xs_rhs_k,
+            stride_o_m,
+            stride_o_n,
+            offs_k,
+            start_ssteps,
+            num_ssteps,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            SCALE_BLOCK_SIZE_N,
+            SCALE_BLOCK_SIZE_K,
+            SPLIT_K,
         )
 
 
 # NOTE (yiakwy) : triton version implementation for tuning, not used in the final product
 def thunder_moun_gemm(
-        xq_lhs : torch.Tensor, 
-        xq_rhs : torch.Tensor, 
-        xs_0: torch.Tensor, 
-        xs_1: torch.Tensor, 
-        out: Optional[torch.Tensor] = None, 
-        online_quant: bool=False, 
-        SPLIT_K : int=1):
+    xq_lhs: torch.Tensor,
+    xq_rhs: torch.Tensor,
+    xs_0: torch.Tensor,
+    xs_1: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    online_quant: bool = False,
+    SPLIT_K: int = 1,
+):
     M, K = xq_lhs.shape
     if out is None:
         out = torch.zeros((M, M), device=xq_lhs.device, dtype=torch.float16)
 
     # dipatch to kernel
-    grid = lambda META: (
-        SPLIT_K,
-        triton.cdiv(M // 2, META["BLOCK_SIZE_M"]),
-        1
-    )
+    grid = lambda META: (SPLIT_K, triton.cdiv(M // 2, META["BLOCK_SIZE_M"]), 1)
     kernel = paired_symm_moun_mat_fp8_block_scaled_tuned_kernel
 
     if USE_TVM_FFI:
+
         def get_stable_kernel_key(M, K, **kwargs):
-            key_str = f"M{M}_K{K}_" + "_".join(f"{k}{v}" for k, v in sorted(kwargs.items()))
-            return hashlib.md5(key_str.encode('utf-8')).hexdigest()
-        
+            key_str = f"M{M}_K{K}_" + "_".join(
+                f"{k}{v}" for k, v in sorted(kwargs.items())
+            )
+            return hashlib.md5(key_str.encode("utf-8")).hexdigest()
+
         key = get_stable_kernel_key(M, K, SPLIT_K=SPLIT_K)
 
-        if tvm_ffi_modules["thunder_moun_gemm"] is not None and tvm_ffi_modules["thunder_moun_gemm"].get(key, None) is not None:
+        if (
+            tvm_ffi_modules["thunder_moun_gemm"] is not None
+            and tvm_ffi_modules["thunder_moun_gemm"].get(key, None) is not None
+        ):
             module, grid = tvm_ffi_modules["thunder_moun_gemm"][key]
             gx, gy, gz = grid
 
@@ -484,34 +552,39 @@ def thunder_moun_gemm(
                 xq_lhs,
                 xq_rhs,
                 out,
-                M, 
+                M,
                 K,
-                xq_lhs.stride(0), xq_lhs.stride(1),
-                out.stride(0), out.stride(1),
+                xq_lhs.stride(0),
+                xq_lhs.stride(1),
+                out.stride(0),
+                out.stride(1),
                 xs_0,
                 xs_1,
-                xs_0.stride(0), xs_0.stride(1),
-                xs_1.stride(0), xs_1.stride(1),
+                xs_0.stride(0),
+                xs_0.stride(1),
+                xs_1.stride(0),
+                xs_1.stride(1),
                 SCALE_BLOCK_SIZE_K=128,
                 SCALE_BLOCK_SIZE_N=128,
                 NUM_XCDS=NUM_XCDS,
                 NUM_CUs=NUM_CUs,
                 SPLIT_K=SPLIT_K,
-                M_EVEN=M%2==0
+                M_EVEN=M % 2 == 0,
             )
 
             # make triton cubins
             cubin_bytes = compiled_kernel.kernel
-            # cubin_ptr = ctypes.cast(ctypes.c_char_p(cubin_bytes), ctypes.c_void_p).value
 
             kernel_name = compiled_kernel.name
             sources, constants = generate_tvm_ffi_source(compiled_kernel, kernel_name)
 
             # register tvm ffi cubin launcher
-            module = tvm_ffi.cpp.load_inline("triton_loader", 
-                                            cuda_sources=sources,
-                                            extra_ldflags=["-lcudart", "-lcuda"],
-                                            embed_cubin={"triton_cubin": cubin_bytes})
+            module = tvm_ffi.cpp.load_inline(
+                "triton_loader",
+                cuda_sources=sources,
+                extra_ldflags=["-lcudart", "-lcuda"],
+                embed_cubin={"triton_cubin": cubin_bytes},
+            )
 
             gx = SPLIT_K
             gy = triton.cdiv(M // 2, constants["BLOCK_SIZE_M"][1])
@@ -531,14 +604,21 @@ def thunder_moun_gemm(
             xq_lhs,
             xq_rhs,
             out,
-            int(M), int(K),
-            int(xq_lhs.stride(0)), int(xq_lhs.stride(1)),
-            int(out.stride(0)), int(out.stride(1)),
+            int(M),
+            int(K),
+            int(xq_lhs.stride(0)),
+            int(xq_lhs.stride(1)),
+            int(out.stride(0)),
+            int(out.stride(1)),
             xs_0,
             xs_1,
-            int(xs_0.stride(0)), int(xs_0.stride(1)),
-            int(xs_1.stride(0)), int(xs_1.stride(1)),
-            int(gx), int(gy), int(gz)
+            int(xs_0.stride(0)),
+            int(xs_0.stride(1)),
+            int(xs_1.stride(0)),
+            int(xs_1.stride(1)),
+            int(gx),
+            int(gy),
+            int(gz),
         )
         return out
     else:
@@ -546,20 +626,24 @@ def thunder_moun_gemm(
             xq_lhs,
             xq_rhs,
             out,
-            M, 
+            M,
             K,
-            xq_lhs.stride(0), xq_lhs.stride(1),
-            out.stride(0), out.stride(1),
+            xq_lhs.stride(0),
+            xq_lhs.stride(1),
+            out.stride(0),
+            out.stride(1),
             xs_0,
             xs_1,
-            xs_0.stride(0), xs_0.stride(1),
-            xs_1.stride(0), xs_1.stride(1),
+            xs_0.stride(0),
+            xs_0.stride(1),
+            xs_1.stride(0),
+            xs_1.stride(1),
             SCALE_BLOCK_SIZE_K=128,
             SCALE_BLOCK_SIZE_N=128,
             NUM_XCDS=NUM_XCDS,
             NUM_CUs=NUM_CUs,
             SPLIT_K=SPLIT_K,
-            M_EVEN=M%2==0
+            M_EVEN=M % 2 == 0,
         )
 
     return out
@@ -567,9 +651,9 @@ def thunder_moun_gemm(
 
 # NOTE (yiakwy) : triton normal block scale mm kernel for performance comparison, not used in the final product
 def get_pack_size(
-        pack_int8=False,
-        pack_int16=False,
-        pack_int32=False,
+    pack_int8=False,
+    pack_int16=False,
+    pack_int32=False,
 ):
     if pack_int8:
         return 8
@@ -582,16 +666,38 @@ def get_pack_size(
 
 @triton.autotune(
     configs=[
-        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 16, 'NUM_STAGES': 3}, num_stages=3, num_warps=16, maxnreg=384),
-        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 16, 'NUM_STAGES': 3}, num_stages=3, num_warps=8, maxnreg=384),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 64,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 16,
+                "NUM_STAGES": 3,
+            },
+            num_stages=3,
+            num_warps=16,
+            maxnreg=384,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 64,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 64,
+                "GROUP_SIZE_M": 16,
+                "NUM_STAGES": 3,
+            },
+            num_stages=3,
+            num_warps=8,
+            maxnreg=384,
+        ),
     ],
-    key=('M', 'N', 'K'),
-    use_cuda_graph=True,
+    key=("M", "N", "K"),
+    use_cuda_graph=False,
 )
 @triton.heuristics(
     {
         "GRID_MN": lambda args: triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
-            * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+        * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
         "BLOCKS_PER_XCD": lambda args: triton.cdiv(
             triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
             * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
@@ -599,14 +705,18 @@ def get_pack_size(
         ),
         "NUM_PID_M": lambda args: triton.cdiv(args["M"], args["BLOCK_SIZE_M"]),
         "NUM_PID_N": lambda args: triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
-        "SPLIT_K":   lambda args: 1, # triton does not support NoC, SPLIT_K usually won't work unless the K dimension is extremely large
-        "w1a16": lambda args: args.get("pack_int8", False) or args.get("pack_int16", False) or args.get("pack_int32", False), # need to be consistent with the data layout of wq
+        "SPLIT_K": lambda _: 1,  # triton does not support NoC, SPLIT_K usually won't work unless the K dimension is extremely large
+        "w1a16": lambda args: args.get("pack_int8", False)
+        or args.get("pack_int16", False)
+        or args.get(
+            "pack_int32", False
+        ),  # need to be consistent with the data layout of wq
         "packed_size": lambda args: get_pack_size(
-            pack_int8 =args.get("pack_int8" , False),
+            pack_int8=args.get("pack_int8", False),
             pack_int16=args.get("pack_int16", False),
-            pack_int32=args.get("pack_int32", False)
+            pack_int32=args.get("pack_int32", False),
         ),
-        "_is_hopper": lambda args: is_hopper(),
+        "_is_hopper": lambda args: args.get("_is_hopper", is_hopper()),
     }
 )
 @triton.jit
@@ -667,7 +777,7 @@ def fp8_streamk_gemm_block_scaled_tuned_kernel(
         start_ssteps = pid_k * num_ssteps
         offs_k += start_ssteps * BLOCK_SIZE_K
         if w1a16:
-            offs_k_packed += start_ssteps * BLOCK_SIZE_K //  packed_size
+            offs_k_packed += start_ssteps * BLOCK_SIZE_K // packed_size
 
         pid_m, pid_n = _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M)
 
@@ -708,16 +818,18 @@ def fp8_streamk_gemm_block_scaled_tuned_kernel(
                 + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
             )
 
-        acc_dtype = tl.float16 # tl.float32
+        acc_dtype = tl.float16  # tl.float32
         acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
 
         if not w1a16:
             xs_next = tl.load(xs_block_ptr)
             ws_next = tl.load(ws_block_ptr)
 
-        # NOTE (yiakwy) : different from 
+        # NOTE (yiakwy) : different from
         last_ssteps = start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
-        for k in tl.range(start_ssteps, start_ssteps + num_ssteps, num_stages=NUM_STAGES):
+        for k in tl.range(
+            start_ssteps, start_ssteps + num_ssteps, num_stages=NUM_STAGES
+        ):
             xq = tl.load(
                 xq_block_ptr,
                 mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
@@ -727,7 +839,8 @@ def fp8_streamk_gemm_block_scaled_tuned_kernel(
             if w1a16:
                 wq = tl.load(
                     wq_block_ptr,
-                    mask=offs_k_packed[None, :] < K // packed_size - k * (BLOCK_SIZE_K // packed_size),
+                    mask=offs_k_packed[None, :]
+                    < K // packed_size - k * (BLOCK_SIZE_K // packed_size),
                     other=0.0,
                 )
 
@@ -736,7 +849,7 @@ def fp8_streamk_gemm_block_scaled_tuned_kernel(
 
                 wq = tl.inline_asm_elementwise(
                     asm="bfe.u32 $0, $1, $2, 1;",
-                    constraints="=r,r,r",   
+                    constraints="=r,r,r",
                     args=[wq, unpack_offs[None, None, :]],
                     dtype=wq_ptr.type.element_ty,
                     is_pure=True,
@@ -744,7 +857,7 @@ def fp8_streamk_gemm_block_scaled_tuned_kernel(
                 )
 
                 wq = wq.reshape((BLOCK_SIZE_N, BLOCK_SIZE_K))
-                wq = (wq * 2 - 1)
+                wq = wq * 2 - 1
                 wq = wq.to(tl.float16)
 
                 if use_w1a16_as_fp8:
@@ -780,14 +893,20 @@ def fp8_streamk_gemm_block_scaled_tuned_kernel(
             if w1a16:
                 acc = tl.dot(xq, wq.trans(1, 0), acc=acc, out_dtype=acc_dtype)
             else:
-                if False: # _is_hopper:
+                if False:  # _is_hopper:
                     # acc = tl.dot_scaled(xq, xs.reshape(BLOCK_SIZE_M, 1), "e4m3", wq.trans(1, 0), ws.reshape(BLOCK_SIZE_N, 1), "e4m3", acc, out_dtype=acc_dtype)
-                    acc = tl.dot(xq * xs[:, None], (wq * ws[:, None]).trans(1, 0), acc=acc, input_precision="ieee", out_dtype=acc_dtype)
+                    acc = tl.dot(
+                        xq * xs[:, None],
+                        (wq * ws[:, None]).trans(1, 0),
+                        acc=acc,
+                        input_precision="ieee",
+                        out_dtype=acc_dtype,
+                    )
                 else:
                     # (xq * xs) @ (bq * bs).T = { cij = xs_i*ws_j* sum_k (xq_ik * wq_kj) }
-                    acc += tl.dot(xq, wq.trans(1, 0), input_precision="ieee", out_dtype=acc_dtype) * (
-                        (xs[:, None] * ws[None, :]).to(acc_dtype)
-                    )
+                    acc += tl.dot(
+                        xq, wq.trans(1, 0), input_precision="ieee", out_dtype=acc_dtype
+                    ) * ((xs[:, None] * ws[None, :]).to(acc_dtype))
 
             xq_block_ptr += BLOCK_SIZE_K * stride_xq_k
             if w1a16:
@@ -816,6 +935,298 @@ def fp8_streamk_gemm_block_scaled_tuned_kernel(
             tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
 
 
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 64,
+                "GROUP_SIZE_M": 16,
+                "NUM_STAGES": 3,
+            },
+            num_stages=3,
+            num_warps=8,
+            maxnreg=384,
+        ),
+    ],
+    key=("M", "N", "K"),
+    use_cuda_graph=False,  # True,
+)
+@triton.heuristics(
+    {
+        "GRID_MN": lambda args: (
+            triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+            * triton.cdiv(args["N"], args["BLOCK_SIZE_N"])
+            + triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+        )
+        // 2,
+        "BLOCKS_PER_XCD": lambda args: triton.cdiv(
+            triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+            * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+            NUM_XCDS,
+        ),
+        "NUM_PID_M": lambda args: triton.cdiv(args["M"], args["BLOCK_SIZE_M"]),
+        "NUM_PID_N": lambda args: triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+        "SPLIT_K": lambda _: 1,  # triton does not support NoC, SPLIT_K usually won't work unless the K dimension is extremely large
+        "w1a16": lambda args: args.get("pack_int8", False)
+        or args.get("pack_int16", False)
+        or args.get(
+            "pack_int32", False
+        ),  # need to be consistent with the data layout of wq
+        "packed_size": lambda args: get_pack_size(
+            pack_int8=args.get("pack_int8", False),
+            pack_int16=args.get("pack_int16", False),
+            pack_int32=args.get("pack_int32", False),
+        ),
+        "_is_hopper": lambda args: args.get("_is_hopper", is_hopper()),
+        "_is_symm": lambda args: args.get("_is_symm", True),
+    }
+)
+@triton.jit
+def fp8_streamk_symm_gemm_block_scaled_tuned_kernel(
+    xq_ptr,
+    wq_ptr,
+    o_ptr,
+    M,
+    N,
+    K,
+    stride_xq_m,
+    stride_xq_k,
+    stride_wq_n,
+    stride_wq_k,
+    stride_o_m,
+    stride_o_n,
+    xs_ptr,
+    ws_ptr,
+    stride_xs_m,
+    stride_xs_k,
+    stride_ws_n,
+    stride_ws_k,
+    SCALE_BLOCK_SIZE_K: tl.constexpr,
+    SCALE_BLOCK_SIZE_N: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_CUs: tl.constexpr,
+    GRID_MN: tl.constexpr,
+    BLOCKS_PER_XCD: tl.constexpr,
+    NUM_PID_M: tl.constexpr,
+    NUM_PID_N: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    w1a16: tl.constexpr,
+    packed_size: tl.constexpr,
+    use_w1a16_as_fp8: tl.constexpr,
+    use_w1a8: tl.constexpr,
+    _is_hopper: tl.constexpr,
+    _is_symm: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+
+    num_pid_m = NUM_PID_M
+    num_pid_n = NUM_PID_N
+
+    tl.static_assert(
+        _is_symm,
+        "This streamk_symm_gemm kernel is designed for symmetric matrix multiplication, please set _is_symm to True.",
+    )
+    tl.static_assert(
+        NUM_PID_M == NUM_PID_N,
+        "The streamk_symm_gemm  kernel currently only support BLOCK_SIZE_M == BLOCK_SIZE_N.",
+    )
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    if w1a16:
+        offs_k_packed = tl.arange(0, BLOCK_SIZE_K // packed_size)
+
+    num_ssteps = tl.cdiv(K, BLOCK_SIZE_K * SPLIT_K)
+
+    for tile_id_0 in tl.range(pid, GRID_MN * SPLIT_K, NUM_CUs):
+        tile_id = tile_id_0 % GRID_MN
+        pid_k = tile_id_0 // GRID_MN
+
+        start_ssteps = pid_k * num_ssteps
+        offs_k += start_ssteps * BLOCK_SIZE_K
+        if w1a16:
+            offs_k_packed += start_ssteps * BLOCK_SIZE_K // packed_size
+
+        if _is_symm:
+            pid_m, pid_n = linear_to_tril(tile_id)
+        else:
+            pid_m, pid_n = _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+        offs_xq_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+        offs_wq_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+
+        # (BLOCK_SIZE_M, BLOCK_SIZE_K)
+        xq_block_ptr = xq_ptr + (
+            offs_xq_m[:, None] * stride_xq_m + offs_k[None, :] * stride_xq_k
+        )
+        if w1a16:
+            # bits to unpack
+            unpack_offs = tl.arange(0, packed_size).to(wq_ptr.type.element_ty)
+
+            # (BLOCK_SIZE_N, BLOCK_SIZE_K // packed_size)
+            wq_block_ptr = wq_ptr + (
+                offs_wq_n[:, None] * stride_wq_n + offs_k_packed[None, :] * stride_wq_k
+            )
+
+        else:
+            # (BLOCK_SIZE_N, BLOCK_SIZE_K)
+            wq_block_ptr = wq_ptr + (
+                offs_wq_n[:, None] * stride_wq_n + offs_k[None, :] * stride_wq_k
+            )
+
+            # (BLOCK_SIZE_M, )
+            xs_block_ptr = (
+                xs_ptr
+                + offs_xq_m * stride_xs_m
+                + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            )
+
+            offs_ws_n = offs_wq_n // SCALE_BLOCK_SIZE_N
+            # (BLOCK_SIZE_N, )
+            ws_block_ptr = (
+                ws_ptr
+                + offs_ws_n * stride_ws_n
+                + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            )
+
+        acc_dtype = tl.float16  # tl.float32
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+
+        if not w1a16:
+            xs_next = tl.load(xs_block_ptr)
+            ws_next = tl.load(ws_block_ptr)
+
+        # NOTE (yiakwy) : different from
+        last_ssteps = start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+        for k in tl.range(
+            start_ssteps, start_ssteps + num_ssteps, num_stages=NUM_STAGES
+        ):
+            xq = tl.load(
+                xq_block_ptr,
+                mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+                other=0.0,
+            )
+
+            if w1a16:
+                wq = tl.load(
+                    wq_block_ptr,
+                    mask=offs_k_packed[None, :]
+                    < K // packed_size - k * (BLOCK_SIZE_K // packed_size),
+                    other=0.0,
+                )
+
+                # NOTE(yiakwy) : w1a16, unpack (BLOCK_SIZE_N, BLOCK_SIZE_K // pack_size) to (BLOCK_SIZE_N, pack_size, BLOCK_SIZE_K // pack_size)
+                wq = wq[:, :, None]
+
+                wq = tl.inline_asm_elementwise(
+                    asm="bfe.u32 $0, $1, $2, 1;",
+                    constraints="=r,r,r",
+                    args=[wq, unpack_offs[None, None, :]],
+                    dtype=wq_ptr.type.element_ty,
+                    is_pure=True,
+                    pack=1,
+                )
+
+                wq = wq.reshape((BLOCK_SIZE_N, BLOCK_SIZE_K))
+                wq = wq * 2 - 1
+                wq = wq.to(tl.float16)
+
+                if use_w1a16_as_fp8:
+                    wq = wq.to(tl.float8e4nv)
+                    xq = xq.to(tl.float8e4nv)
+                elif use_w1a8:
+                    wq = wq.to(tl.float8e4nv)
+
+            else:
+                wq = tl.load(
+                    wq_block_ptr,
+                    mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+                    other=0.0,
+                )
+
+                if wq.dtype == tl.int8 or wq.dtype == tl.int16:
+                    wq = wq.to(tl.float16)
+
+                    if use_w1a16_as_fp8:
+                        wq = wq.to(tl.float8e4nv)
+                        xq = xq.to(tl.float8e4nv)
+                    elif use_w1a8:
+                        wq = wq.to(tl.float8e4nv)
+
+            ws = ws_next
+            xs = xs_next
+
+            cur_ssteps = (k + 1) * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            if cur_ssteps > last_ssteps and (k + 1) < num_ssteps:
+                xs_next = tl.load(xs_block_ptr + stride_xs_k)
+                ws_next = tl.load(ws_block_ptr + stride_ws_k)
+
+            if w1a16:
+                acc = tl.dot(xq, wq.trans(1, 0), acc=acc, out_dtype=acc_dtype)
+            else:
+                if False:  # _is_hopper:
+                    # acc = tl.dot_scaled(xq, xs.reshape(BLOCK_SIZE_M, 1), "e4m3", wq.trans(1, 0), ws.reshape(BLOCK_SIZE_N, 1), "e4m3", acc, out_dtype=acc_dtype)
+                    acc = tl.dot(
+                        xq * xs[:, None],
+                        (wq * ws[:, None]).trans(1, 0),
+                        acc=acc,
+                        input_precision="ieee",
+                        out_dtype=acc_dtype,
+                    )
+                else:
+                    # (xq * xs) @ (bq * bs).T = { cij = xs_i*ws_j* sum_k (xq_ik * wq_kj) }
+                    acc += tl.dot(
+                        xq, wq.trans(1, 0), input_precision="ieee", out_dtype=acc_dtype
+                    ) * ((xs[:, None] * ws[None, :]).to(acc_dtype))
+
+            xq_block_ptr += BLOCK_SIZE_K * stride_xq_k
+            if w1a16:
+                wq_block_ptr += BLOCK_SIZE_K // packed_size * stride_wq_k
+            else:
+                wq_block_ptr += BLOCK_SIZE_K * stride_wq_k
+
+            if cur_ssteps > last_ssteps and (k + 1) < num_ssteps:
+                xs_block_ptr += stride_xs_k
+                ws_block_ptr += stride_ws_k
+
+            last_ssteps = cur_ssteps
+
+        o_block_ptr = (
+            o_ptr + offs_xq_m[:, None] * stride_o_m + offs_wq_n[None, :] * stride_o_n
+        )
+        o_mask = (offs_xq_m[:, None] < M) & (offs_wq_n[None, :] < N)
+
+        if o_ptr.type.element_ty != acc.dtype:
+            _acc = acc.to(o_ptr.type.element_ty)
+        else:
+            _acc = acc
+        if SPLIT_K == 1:
+            tl.store(o_block_ptr, _acc, mask=o_mask)
+        else:
+            tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+        if _is_symm:
+            # transpose copy for the symmetric tile
+            if pid_n < pid_m:
+                _acc = tl.trans(_acc, 1, 0)
+                o_block_ptr = (
+                    o_ptr
+                    + offs_wq_n[:, None] * stride_o_m
+                    + offs_xq_m[None, :] * stride_o_n
+                )
+                o_mask = (offs_wq_n[:, None] < M) & (offs_xq_m[None, :] < M)
+                if SPLIT_K == 1:
+                    tl.store(o_block_ptr, _acc, mask=o_mask)
+                else:
+                    tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+
 def fp8_gemm_block_scaled(
     xq: torch.Tensor,
     wq: torch.Tensor,
@@ -825,6 +1236,7 @@ def fp8_gemm_block_scaled(
     SCALE_BLOCK_SIZE_N=128,
     SCALE_BLOCK_SIZE_K=128,
     check_input_shape=False,
+    is_symm=False,
 ):
     if check_input_shape:
         assert xq.dim() >= 2, "xq must be >= 2 dims"
@@ -846,29 +1258,52 @@ def fp8_gemm_block_scaled(
         o = torch.zeros((M, N), device=xq.device, dtype=torch.float16)
 
     # dispatch to kernel
-    grid = lambda META: (
-        min(
-            NUM_CUs,
-            triton.cdiv(M, META["BLOCK_SIZE_M"])
-            * triton.cdiv(N, META["BLOCK_SIZE_N"])
-            * META["SPLIT_K"],
-        ),
-    )
-    kernel = fp8_streamk_gemm_block_scaled_tuned_kernel
+    if is_symm:
+        grid = lambda META: (
+            min(
+                NUM_CUs,
+                (
+                    (
+                        triton.cdiv(M, META["BLOCK_SIZE_M"])
+                        * triton.cdiv(N, META["BLOCK_SIZE_N"])
+                        + triton.cdiv(M, META["BLOCK_SIZE_M"])
+                    )
+                    // 2
+                )
+                * META["SPLIT_K"],
+            ),
+        )
+
+        kernel = fp8_streamk_symm_gemm_block_scaled_tuned_kernel
+    else:
+        grid = lambda META: (
+            min(
+                NUM_CUs,
+                triton.cdiv(M, META["BLOCK_SIZE_M"])
+                * triton.cdiv(N, META["BLOCK_SIZE_N"])
+                * META["SPLIT_K"],
+            ),
+        )
+
+        kernel = fp8_streamk_gemm_block_scaled_tuned_kernel
 
     if USE_TVM_FFI:
         global tvm_ffi_modules
 
-        def get_stable_kernel_key(M, N, K, **kwargs):
-            key_str = f"M{M}_N{N}_K{K}_" + "_".join(f"{k}{v}" for k, v in sorted(kwargs.items()))
-            return hashlib.md5(key_str.encode('utf-8')).hexdigest()
-        
-        key = get_stable_kernel_key(M, N, K, SPLIT_K=1)
+        def get_stable_kernel_key(M, N, K, is_symm, **kwargs):
+            key_str = f"M{M}_N{N}_K{K}_{1 if is_symm else 0}_" + "_".join(
+                f"{k}{v}" for k, v in sorted(kwargs.items())
+            )
+            return hashlib.md5(key_str.encode("utf-8")).hexdigest()
 
-        if tvm_ffi_modules["fp8_gemm_block_scaled"] is not None and tvm_ffi_modules["fp8_gemm_block_scaled"].get(key, None) is not None:
+        key = get_stable_kernel_key(M, N, K, is_symm, SPLIT_K=1)
+
+        if (
+            tvm_ffi_modules["fp8_gemm_block_scaled"] is not None
+            and tvm_ffi_modules["fp8_gemm_block_scaled"].get(key, None) is not None
+        ):
             module, grid = tvm_ffi_modules["fp8_gemm_block_scaled"][key]
             gx, gy, gz = grid
-
         else:
             # compile
             compiled_kernel = kernel[grid](
@@ -878,13 +1313,18 @@ def fp8_gemm_block_scaled(
                 M,
                 N,
                 K,
-                xq.stride(0), xq.stride(1),
-                wq.stride(0), wq.stride(1),
-                o.stride(0), o.stride(1),
+                xq.stride(0),
+                xq.stride(1),
+                wq.stride(0),
+                wq.stride(1),
+                o.stride(0),
+                o.stride(1),
                 xs,
                 ws,
-                xs.stride(0), xs.stride(1),
-                ws.stride(0), ws.stride(1),
+                xs.stride(0),
+                xs.stride(1),
+                ws.stride(0),
+                ws.stride(1),
                 SCALE_BLOCK_SIZE_N=SCALE_BLOCK_SIZE_N,
                 SCALE_BLOCK_SIZE_K=SCALE_BLOCK_SIZE_K,
                 NUM_XCDS=NUM_XCDS,
@@ -895,23 +1335,38 @@ def fp8_gemm_block_scaled(
 
             # make triton cubins
             cubin_bytes = compiled_kernel.kernel
-            # cubin_ptr = ctypes.cast(ctypes.c_char_p(cubin_bytes), ctypes.c_void_p).value
-            
+
             kernel_name = compiled_kernel.name
             sources, constants = generate_tvm_ffi_source(compiled_kernel, kernel_name)
 
             # register tvm ffi cubin launcher
-            module = tvm_ffi.cpp.load_inline("triton_loader", 
-                                            cuda_sources=sources,
-                                            extra_ldflags=["-lcudart", "-lcuda"],
-                                            embed_cubin={"triton_cubin": cubin_bytes})
-
-            gx = min(
-                NUM_CUs,
-                triton.cdiv(M, constants["BLOCK_SIZE_M"][1])
-                * triton.cdiv(N, constants["BLOCK_SIZE_N"][1])
-                * constants["BLOCK_SIZE_K"][1],
+            module = tvm_ffi.cpp.load_inline(
+                "triton_loader",
+                cuda_sources=sources,
+                extra_ldflags=["-lcudart", "-lcuda"],
+                embed_cubin={"triton_cubin": cubin_bytes},
             )
+
+            if is_symm:
+                gx = min(
+                    NUM_CUs,
+                    (
+                        (
+                            triton.cdiv(M, constants["BLOCK_SIZE_M"][1])
+                            * triton.cdiv(N, constants["BLOCK_SIZE_N"][1])
+                            + constants["BLOCK_SIZE_M"][1]
+                        )
+                        // 2
+                    )
+                    * constants["SPLIT_K"][1],
+                )
+            else:
+                gx = min(
+                    NUM_CUs,
+                    triton.cdiv(M, constants["BLOCK_SIZE_M"][1])
+                    * triton.cdiv(N, constants["BLOCK_SIZE_N"][1])
+                    * constants["BLOCK_SIZE_K"][1],
+                )
             gy = gz = 1
 
             print(f"[{kernel_name}] gx={gx}, gy={gy}, gz={gz}")
@@ -922,26 +1377,55 @@ def fp8_gemm_block_scaled(
 
             tvm_ffi_modules["fp8_gemm_block_scaled"][key] = (module, (gx, gy, gz))
 
-        # for name, tensor in [("xq", xq), ("wq", wq), ("o", o), ("xs", xs), ("ws", ws)]:
-        #     addr = tensor.data_ptr()
-        #     assert addr % 16 == 0, f"{name} address {addr} is not 16-byte aligned! This causes misaligned address error."
-
         # NOTE (yiakwy) : see cubin signature from generate_tvm_ffi_source, only leading dimensions (LD, i.e., **stride(0)** for row major) are kept as arguments, M, N, K are passed through constant memory, need to be consistent with the kernel definition
-        module.fp8_streamk_gemm_block_scaled_tuned_kernel(
-            # cubin_ptr,
-            xq,
-            wq,
-            o,
-            int(M), int(N), int(K),
-            int(xq.stride(0)), int(xq.stride(1)), 
-            int(wq.stride(0)), int(wq.stride(1)), 
-            int(o.stride(0)), int(o.stride(1)),
-            xs,
-            ws,
-            int(xs.stride(0)), int(xs.stride(1)), 
-            int(ws.stride(0)), int(ws.stride(1)),
-            int(gx), int(gy), int(gz)
-        )
+        if is_symm:
+            module.fp8_streamk_symm_gemm_block_scaled_tuned_kernel(
+                xq,
+                wq,
+                o,
+                int(M),
+                int(N),
+                int(K),
+                int(xq.stride(0)),
+                int(xq.stride(1)),
+                int(wq.stride(0)),
+                int(wq.stride(1)),
+                int(o.stride(0)),
+                int(o.stride(1)),
+                xs,
+                ws,
+                int(xs.stride(0)),
+                int(xs.stride(1)),
+                int(ws.stride(0)),
+                int(ws.stride(1)),
+                int(gx),
+                int(gy),
+                int(gz),
+            )
+        else:
+            module.fp8_streamk_gemm_block_scaled_tuned_kernel(
+                xq,
+                wq,
+                o,
+                int(M),
+                int(N),
+                int(K),
+                int(xq.stride(0)),
+                int(xq.stride(1)),
+                int(wq.stride(0)),
+                int(wq.stride(1)),
+                int(o.stride(0)),
+                int(o.stride(1)),
+                xs,
+                ws,
+                int(xs.stride(0)),
+                int(xs.stride(1)),
+                int(ws.stride(0)),
+                int(ws.stride(1)),
+                int(gx),
+                int(gy),
+                int(gz),
+            )
         return o
     else:
         kernel[grid](
@@ -951,13 +1435,18 @@ def fp8_gemm_block_scaled(
             M,
             N,
             K,
-            xq.stride(0), xq.stride(1),
-            wq.stride(0), wq.stride(1),
-            o.stride(0), o.stride(1),
+            xq.stride(0),
+            xq.stride(1),
+            wq.stride(0),
+            wq.stride(1),
+            o.stride(0),
+            o.stride(1),
             xs,
             ws,
-            xs.stride(0), xs.stride(1),
-            ws.stride(0), ws.stride(1),
+            xs.stride(0),
+            xs.stride(1),
+            ws.stride(0),
+            ws.stride(1),
             SCALE_BLOCK_SIZE_N=SCALE_BLOCK_SIZE_N,
             SCALE_BLOCK_SIZE_K=SCALE_BLOCK_SIZE_K,
             NUM_XCDS=NUM_XCDS,

--- a/jit_kernel/triton3_4/tvm_ffi_mod.py
+++ b/jit_kernel/triton3_4/tvm_ffi_mod.py
@@ -1,0 +1,159 @@
+import triton
+
+import tvm_ffi
+
+from packaging import version
+
+# Triton 3.4
+def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
+    # Triton 3.5+
+    if version.parse(triton.__version__) >= version.parse("3.5"):
+        raise Exception("TVM FFI Not Implemented for Triton 3.5+ due to the change of metadata structure, need to update the parsing logic accordingly.")
+    
+    arg_names = compiled_kernel.src.fn.arg_names
+    signature = compiled_kernel.src.fn.signature 
+
+    # cpp_params = ["int64_t cubin_ptr_addr"]   # FFI args list
+    cpp_params = []
+
+    launch_args_def = []  # cuLaunchKernel pointer args list
+    launch_args = []  # cuLaunchKernel args list
+
+    constants = {}
+    constants_set = set()
+    for key, val in compiled_kernel.src.constants.items():
+        name = arg_names[key[0]]
+
+        if "stride_" in name:
+            if debug:
+                print(f"{name} is not regarded as constant")
+            continue
+
+        constants[name] = (key[0], val)
+        constants_set.add(name)
+
+    if debug:
+        print("arg_names : ", arg_names)
+        print("constants : ", constants)
+
+    for name, param in signature.parameters.items():
+        if name in constants_set:
+            continue
+
+        if "ptr" in name:
+            cpp_params.append(f"TensorView {name}")
+            launch_args_def.append(f"void* {name};\n")
+            launch_args.append(f"kargs.{name} = {name}.data_ptr();\n")
+        elif "use_" in name or "is_" in name:
+            cpp_params.append(f"bool {name}")
+            launch_args_def.append(f"bool {name};\n")
+            launch_args.append(f"kargs.{name} = {name};\n")
+        else:
+            cpp_params.append(f"int32_t {name}")
+            launch_args_def.append(f"int32_t {name};\n")
+            launch_args.append(f"kargs.{name} = {name};\n")
+            
+
+    cpp_params_str = ", ".join(cpp_params + ["int32_t grid_x", "int32_t grid_y", "int32_t grid_z"])
+
+    launch_args_def_str = "".join(launch_args_def)
+    launch_args_str = "".join(launch_args)
+
+    if debug:
+        print(f"cpp_params_str : {cpp_params_str}")
+        print(f"launch_args_def_str : {launch_args_def_str}")
+        print(f"launch_args_str : {launch_args_str}")
+
+    META = compiled_kernel.metadata
+
+    num_warps = META.num_warps # compiled_kernel.num_warps
+    shared_mem_size = 24 * 1024 # META.shared
+
+    arch = META.target.arch
+    WARP_SIZE = META.target.warp_size
+
+    source = f"""
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/extra/cuda/cubin_launcher.h>
+#include <tvm/ffi/function.h>
+
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+#include <cuda_runtime.h>
+
+#define USE_TVM_FFI_LAUNCH_CONVENTION 0
+
+TVM_FFI_EMBED_CUBIN(triton_cubin);
+
+namespace triton_loader {{
+using namespace tvm::ffi;
+
+// NOTE (yiakwy) : TVM's official method does not handle alignment issue, hence I use this method to escape alignment problem. 
+// We can also consider to modify TVM's official method to support alignment in the future if necessary.
+struct KernelArgs {{
+    {launch_args_def_str};
+}};
+
+void {kernel_name}_launcher({cpp_params_str}) {{
+    static auto launcher = TVM_FFI_EMBED_CUBIN_GET_KERNEL(triton_cubin, "{kernel_name}");
+
+    // construct Triton arguments list
+    KernelArgs kargs;
+
+    {launch_args_str};
+    
+    cudaGetLastError();
+
+    int shared_mem_bytes = {shared_mem_size};
+    cuDeviceGetAttribute(&shared_mem_bytes, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, 0);
+    
+    CUfunction kernel = *(reinterpret_cast<CUfunction*>(&launcher));
+    cuFuncSetAttribute(kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (unsigned int)shared_mem_bytes);
+    
+    DLDevice device = {arg_names[0]}.device();
+    cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
+
+    tvm::ffi::dim3 grid((unsigned int)grid_x, (unsigned int)grid_y, (unsigned int)grid_z);
+    tvm::ffi::dim3 block({num_warps * WARP_SIZE}, 1, 1);
+
+#if USE_TVM_FFI_LAUNCH_CONVENTION
+    // Launch Kernel : old version does not support to pass shared_mem_bytes, so here is my workaround
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(launcher.Launch(args, grid, block, stream, shared_mem_bytes));
+
+
+#else
+    size_t kargs_size = sizeof(KernelArgs);
+    void* config[] = {{
+        CU_LAUNCH_PARAM_BUFFER_POINTER, &kargs,
+        CU_LAUNCH_PARAM_BUFFER_SIZE,    &kargs_size,
+        CU_LAUNCH_PARAM_END
+    }};  
+
+    // see https://github.com/apache/tvm-ffi/blob/d73a26783488430986fd855ae67ff7a9fb016413/include/tvm/ffi/extra/cuda/internal/unified_api.h#L115
+    /*  
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(
+        cuLaunchKernel(kernel, 
+          grid.x, grid.y, grid.z, 
+          block.x, block.y, block.z, 
+          (unsigned int)shared_mem_bytes, stream, nullptr, config);
+    ));
+    */
+
+    CUresult result = cuLaunchKernel(kernel, 
+          grid.x, grid.y, grid.z, 
+          block.x, block.y, block.z, 
+          (unsigned int)shared_mem_bytes, stream, nullptr, config);
+
+    if (result != CUDA_SUCCESS) {{
+        // TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(result));
+    }}
+
+    // cudaDeviceSynchronize();
+#endif
+}}
+
+}} // namespace triton_loader
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC({kernel_name}, triton_loader::{kernel_name}_launcher);
+"""
+    return source, constants 


### PR DESCRIPTION
## Thunder Muon Triton low latency implementation baseline with TVM-FFI support

  <p align="center">
  <img width="571" height="539" alt="Thunder Moun Gemm" src="https://github.com/user-attachments/assets/d49b9f7f-c9fa-467d-9b67-f38fd19b0bfd" />
  <br>
  <em>Thunder Gemm Benchmark (for LLM hiddensize workload)</em>
  </p>

#### System Requirement

Our training system mainly support 

- py312+torch2.8+cu128+triton3.4+tvm-ffi@0.1.10

```
>>> import tvm_ffi
>>> tvm_ffi.__version__
'0.1.10'
>>> import sglang
>>> import sgl_kernel
>>> sglang.__version__
'0.5.10.post2.dev720+g8043374dd'
>>> sgl_kernel.__version__
'0.4.1'
```

While our infernce system supports both 

- py312+torch2.9.1+cu12.9+SGLANG-latest+vllm-latest+tvm-ffi-latest
- py312+torch2.11+cu130+SGLANG-latest+vall-latest+tvm-ffi-laest

#### Algorithm Description

After carefully examing Muon and Right Poplar Decomposition, we wrote manuscript (in latex) by examping different convergent formulas.

In this PR we provide two version as CUDA implement references:

- symmetric matmul with Z distribution : 
   
   Inspired by the previous work [**Load Balance Attention with average 30% fwd acceleration**](https://github.com/yiakwy-xpu-ml-framework-team/OpenAI-triton/blob/33cd0160b2e7fffd79048a8b19aa972896a54d70/python/triton/ops/flash_attention.py) , (see [test results](https://github.com/triton-lang/triton/pull/3373), [test_source](https://github.com/yiakwy-xpu-ml-framework-team/OpenAI-triton/blob/33cd0160b2e7fffd79048a8b19aa972896a54d70/python/test/unit/hopper/test_flashattention.p) for details), symmetric matmul suffers from load balancing problem in our tests and we hence propose and implemented so called "ThunderMuon" to resolve the issue arised from our **ThunderMuon** optimizer.
   
  <p align="center">
  <img width="438" height="441" alt="Our thunder moun sym gemm illustration" src="https://github.com/user-attachments/assets/0cd067cd-841b-4d55-be4b-1d958cf931a4" />
  <br>
  <em>Our Thunder Muon (demonstration of non-group scheduling scheme, i.e Zig-Zag style (group by group),  from our course representation material in latex)</em>
  </p>
   

- CUDA JIT for symmetric matmul


Note to compete against SOTA gemm, we added TVM-FFI, which reduced the host launch overhead to `5` $\mu$ seconds

