### PR TITLE
[Fix] Fix Triton 3.4 TVM FFI cubin launcher

### DIFF
--- a/jit_kernel/triton3_4/tvm_ffi_mod.py
+++ b/jit_kernel/triton3_4/tvm_ffi_mod.py
@@ -4,30 +4,73 @@ import tvm_ffi
 
 from packaging import version
 
+import inspect
+import triton.language as tl
+
+def is_constexpr_param(param):
+    ann = param.annotation
+    if ann is inspect._empty:
+        return False
+    return ann is tl.constexpr or getattr(ann, "__name__", "") == "constexpr" or "constexpr" in str(ann)
+
+def cpp_host_type(name: str) -> str:
+    if "ptr" in name:
+        return "TensorView"
+    if "use_" in name or "is_" in name:
+        return "bool"
+    return "int32_t"
+
+
+def kernel_arg_type(name: str) -> str:
+    if "ptr" in name:
+        return "void*"
+    if "use_" in name or "is_" in name:
+        return "bool"
+    return "int32_t"
+
+def kernel_arg_assignment(name: str) -> str:
+    if "ptr" in name:
+        return f"kargs.{name} = {name}.data_ptr();\n"
+    return f"kargs.{name} = {name};\n"
+
+def runtime_arg_decl(name: str) -> str:
+    var = f"{name}_arg"
+    if "ptr" in name:
+        return f"void* {var} = {name}.data_ptr();\n"
+    if "use_" in name or "is_" in name:
+        return f"bool {var} = {name};\n"
+    return f"int32_t {var} = {name};\n"
+
 # Triton 3.4
 def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
     # Triton 3.5+
     if version.parse(triton.__version__) >= version.parse("3.5"):
         raise Exception("TVM FFI Not Implemented for Triton 3.5+ due to the change of metadata structure, need to update the parsing logic accordingly.")
     
+    if debug:
+        print(compiled_kernel.metadata)
+        print(compiled_kernel.asm["ptx"].split(".entry", 1)[1].split(")", 1)[0])
+
     arg_names = compiled_kernel.src.fn.arg_names
     signature = compiled_kernel.src.fn.signature 
 
     # cpp_params = ["int64_t cubin_ptr_addr"]   # FFI args list
     cpp_params = []
+    cpp_arg_names = []
 
     launch_args_def = []  # cuLaunchKernel pointer args list
     launch_args = []  # cuLaunchKernel args list
+    launch_arg_names = []
 
     constants = {}
     constants_set = set()
     for key, val in compiled_kernel.src.constants.items():
         name = arg_names[key[0]]
 
-        if "stride_" in name:
-            if debug:
-                print(f"{name} is not regarded as constant")
-            continue
+        # if "stride_" in name:
+        #     if debug:
+        #         print(f"{name} is not regarded as constant")
+        #     continue
 
         constants[name] = (key[0], val)
         constants_set.add(name)
@@ -37,27 +80,48 @@ def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
         print("constants : ", constants)
 
     for name, param in signature.parameters.items():
-        if name in constants_set:
+        if is_constexpr_param(param):
             continue
 
-        if "ptr" in name:
-            cpp_params.append(f"TensorView {name}")
-            launch_args_def.append(f"void* {name};\n")
-            launch_args.append(f"kargs.{name} = {name}.data_ptr();\n")
-        elif "use_" in name or "is_" in name:
-            cpp_params.append(f"bool {name}")
-            launch_args_def.append(f"bool {name};\n")
-            launch_args.append(f"kargs.{name} = {name};\n")
-        else:
-            cpp_params.append(f"int32_t {name}")
-            launch_args_def.append(f"int32_t {name};\n")
-            launch_args.append(f"kargs.{name} = {name};\n")
-            
+        cpp_arg_names.append(name)
 
+        if name not in constants_set:
+            launch_arg_names.append(name)
+            
+    cpp_params = [f"{cpp_host_type(name)} {name}" for name in cpp_arg_names]
     cpp_params_str = ", ".join(cpp_params + ["int32_t grid_x", "int32_t grid_y", "int32_t grid_z"])
+    
+    launch_args_def = [
+        f"{kernel_arg_type(name)} {name};\n"
+        for name in launch_arg_names
+    ]
+
+    launch_args = [
+        kernel_arg_assignment(name)
+        for name in launch_arg_names
+    ]
+    
+    launch_args_def.append("CUdeviceptr global_scratch;\n")
+    launch_args.append("kargs.global_scratch = 0;\n")
 
     launch_args_def_str = "".join(launch_args_def)
     launch_args_str = "".join(launch_args)
+    
+    runtime_arg_decls = [
+        runtime_arg_decl(name)
+        for name in launch_arg_names
+    ]
+
+    runtime_arg_ptrs = [
+        f"&{name}_arg"
+        for name in launch_arg_names
+    ]
+
+    runtime_arg_decls.append("CUdeviceptr global_scratch_arg = 0;\n")
+    runtime_arg_ptrs.append("&global_scratch_arg")
+
+    runtime_arg_decls_str = "".join(runtime_arg_decls)
+    runtime_arg_ptrs_str = ",\n        ".join(runtime_arg_ptrs)
 
     if debug:
         print(f"cpp_params_str : {cpp_params_str}")
@@ -65,9 +129,12 @@ def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
         print(f"launch_args_str : {launch_args_str}")
 
     META = compiled_kernel.metadata
+    
+    global_scratch_size = getattr(META, "global_scratch_size", 0)
+    global_scratch_align = getattr(META, "global_scratch_align", 1)
 
     num_warps = META.num_warps # compiled_kernel.num_warps
-    shared_mem_size = 24 * 1024 # META.shared
+    shared_mem_size = META.shared
 
     arch = META.target.arch
     WARP_SIZE = META.target.warp_size
@@ -80,6 +147,7 @@ def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
 #include <tvm/ffi/error.h>
 #include <tvm/ffi/extra/c_env_api.h>
 #include <cuda_runtime.h>
+#include <cuda.h>
 
 #define USE_TVM_FFI_LAUNCH_CONVENTION 0
 
@@ -102,16 +170,47 @@ void {kernel_name}_launcher({cpp_params_str}) {{
 
     {launch_args_str};
     
+    //runtime-api
+    {runtime_arg_decls_str}
+
+    void* args[] = {{
+            {runtime_arg_ptrs_str}
+    }};
+        
     cudaGetLastError();
 
     int shared_mem_bytes = {shared_mem_size};
-    cuDeviceGetAttribute(&shared_mem_bytes, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, 0);
+    // cuDeviceGetAttribute(&shared_mem_bytes, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, 0);
     
-    CUfunction kernel = *(reinterpret_cast<CUfunction*>(&launcher));
-    cuFuncSetAttribute(kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (unsigned int)shared_mem_bytes);
+    auto kernel = launcher.GetHandle();
+    // CUfunction kernel = *(reinterpret_cast<CUfunction*>(&launcher));
+    // CUresult attr_result = cuFuncSetAttribute(kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (unsigned int)shared_mem_bytes);
+    
+    /* 
+    if (attr_result != CUDA_SUCCESS) {{
+        TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
+            static_cast<::tvm::ffi::cuda_api::ResultType>(attr_result)
+        );
+    }}
+    */
     
     DLDevice device = {arg_names[0]}.device();
-    cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
+    
+    ::tvm::ffi::cuda_api::StreamHandle stream =
+        static_cast<::tvm::ffi::cuda_api::StreamHandle>(
+            TVMFFIEnvGetStream(device.device_type, device.device_id));
+
+    auto device_handle =
+        ::tvm::ffi::cuda_api::GetDeviceHandle(device.device_id);
+
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
+        ::tvm::ffi::cuda_api::SetKernelMaxDynamicSharedMem(
+            kernel,
+            shared_mem_bytes,
+            device_handle)
+    );
+    
+    // cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
 
     tvm::ffi::dim3 grid((unsigned int)grid_x, (unsigned int)grid_y, (unsigned int)grid_z);
     tvm::ffi::dim3 block({num_warps * WARP_SIZE}, 1, 1);
@@ -122,13 +221,6 @@ void {kernel_name}_launcher({cpp_params_str}) {{
 
 
 #else
-    size_t kargs_size = sizeof(KernelArgs);
-    void* config[] = {{
-        CU_LAUNCH_PARAM_BUFFER_POINTER, &kargs,
-        CU_LAUNCH_PARAM_BUFFER_SIZE,    &kargs_size,
-        CU_LAUNCH_PARAM_END
-    }};  
-
     // see https://github.com/apache/tvm-ffi/blob/d73a26783488430986fd855ae67ff7a9fb016413/include/tvm/ffi/extra/cuda/internal/unified_api.h#L115
     /*  
     TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(
@@ -139,13 +231,36 @@ void {kernel_name}_launcher({cpp_params_str}) {{
     ));
     */
 
-    CUresult result = cuLaunchKernel(kernel, 
+
+#if TVM_FFI_CUBIN_LAUNCHER_USE_DRIVER_API
+    size_t kargs_size = sizeof(KernelArgs);
+    void* config[] = {{
+        CU_LAUNCH_PARAM_BUFFER_POINTER, &kargs,
+        CU_LAUNCH_PARAM_BUFFER_SIZE,    &kargs_size,
+        CU_LAUNCH_PARAM_END
+    }};  
+
+    CUresult result = cuLaunchKernel(
+          reinterpret_cast<CUfunction>(kernel), 
           grid.x, grid.y, grid.z, 
           block.x, block.y, block.z, 
           (unsigned int)shared_mem_bytes, stream, nullptr, config);
 
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(result);
+#else
+    cudaError_t result = cudaLaunchKernel(
+        reinterpret_cast<const void*>(kernel),
+        ::dim3(grid.x, grid.y, grid.z),
+        ::dim3(block.x, block.y, block.z),
+        args,
+        (size_t)shared_mem_bytes,
+        stream);
+
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(result);
+#endif
+
     if (result != CUDA_SUCCESS) {{
-        // TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(result));
+        TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(result));
     }}
 
     // cudaDeviceSynchronize();


### PR DESCRIPTION
## Summary



This PR fixes the Triton 3.4 TVM-FFI cubin launcher used by the Triton Moun benchmark.

While debugging the TVM-FFI cached-launch path, checking the CUDA launch result showed that the cached launcher was not launching successfully. Because the launch error was previously ignored, the benchmark could report unrealistically fast cached-launch timings.

After this change, the launcher checks CUDA launch results properly, and the TVM-FFI cached-launch path reports the actual kernel runtime.


## Changes


- Generate launcher arguments from the Triton kernel signature while skipping `tl.constexpr` params.

- Preserve runtime kernel arguments separately from compile-time constants.

- Add the Triton 3.4 hidden `global_scratch` argument to the cubin ABI.

- Use `META.shared` for dynamic shared memory instead of a hard-coded value.

- Use `launcher.GetHandle()` and set dynamic shared memory through the TVM-FFI CUDA API.

- Add both driver API and runtime API launch paths.

- Check CUDA launch errors instead of silently ignoring launch failures.



## Validation



Tested on:



```text

GPU: NVIDIA H100 PCIe

Capability: (9, 0)

Torch: 2.8.0+cu128

CUDA: 12.8

Triton: 3.4.0

```



Commands:



```bash

python -m py_compile jit_kernel/triton3_4/tvm_ffi_mod.py

python benchmark/moun/bench_symm_gemm.py

```




Native Triton and TVM-FFI report matching runtime for Triton Moun at `M=2048`:



```text

native triton moun 5.083 ms

tvm ffi moun       5.080 ms

```



Benchmark after the fix no longer reports the previously unrealistic cached-launch timings:



```text

M=2048  Triton ThunderMoun kernel: 5.086 ms

M=4096  Triton ThunderMoun kernel: 19.952 ms

M=8192  Triton ThunderMoun kernel: 81.168 ms

```