### PR TITLE
[Gluon Triton] Add gluon 3 5 symm gemm

### DIFF
--- a/benchmark/moun/bench_triton_3_5_cuda_symm_gemm.py
+++ b/benchmark/moun/bench_triton_3_5_cuda_symm_gemm.py
@@ -9,11 +9,10 @@ import triton.language as tl
 import triton.testing
 
 from jit_kernel.thunder_moun import symm_gemm_block_scaled
+from jit_kernel.triton3_5.gluon.symm_gemm import GluonXXT
 
 # TODO (yiakwy) : remove the reference
-from jit_kernel.triton3_5.symm_gemm import XXT, XTX
-
-from jit_kernel.triton3_5.gluon.symm_gemm import GluonXXT
+from jit_kernel.triton3_5.symm_gemm import XTX, XXT
 
 SEED = 42
 
@@ -44,7 +43,7 @@ def fp8_weight_block_wise_quant_kernel(
 ):
     pid_m = tl.program_id(axis=0)
     pid_n = tl.program_id(axis=1)
-    n = tl.cdiv(N, SCALED_BLOCK_SIZE_M)
+    n = tl.cdiv(N, SCALED_BLOCK_SIZE_N)
     offs_m = pid_m * SCALED_BLOCK_SIZE_M + tl.arange(0, SCALED_BLOCK_SIZE_M)
     offs_n = pid_n * SCALED_BLOCK_SIZE_N + tl.arange(0, SCALED_BLOCK_SIZE_N)
     offs = offs_m[:, None] * N + offs_n[None, :]
@@ -85,58 +84,6 @@ def fp8_weight_block_wise_quant(
         SCALED_BLOCK_SIZE_N=scaled_block_size_n,
         FP8_MAX=FP8_MAX,
     )
-    return y, s
-
-
-@triton.jit
-def act_quant_kernel(
-    x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr, FP8_MAX: tl.constexpr
-):
-    """
-    Quantizes the input tensor `x_ptr` and stores the result in `y_ptr` and the scaling factor in `s_ptr`.
-
-    Args:
-        x_ptr (triton.Pointer): Pointer to the input tensor.
-        y_ptr (triton.Pointer): Pointer to the output tensor where quantized values will be stored.
-        s_ptr (triton.Pointer): Pointer to the output tensor where scaling factors will be stored.
-        BLOCK_SIZE (tl.constexpr): The size of the block to be processed by each program instance.
-
-    Returns:
-        None
-    """
-    pid = tl.program_id(axis=0)
-    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    x = tl.load(x_ptr + offs).to(tl.float32)
-    s = tl.max(tl.abs(x)) / FP8_MAX
-    y = x / s
-    y = y.to(y_ptr.dtype.element_ty)
-    tl.store(y_ptr + offs, y)
-    tl.store(s_ptr + pid, s)
-
-
-def act_quant(
-    x: torch.Tensor, block_size: int = 128
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Quantizes the input tensor `x` using block-wise quantization.
-
-    Args:
-        x (torch.Tensor): The input tensor to be quantized. Must be contiguous and its last dimension size must be divisible by `block_size`.
-        block_size (int, optional): The size of the blocks to be used for quantization. Default is 128.
-
-    Returns:
-        Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
-            - The quantized tensor with dtype `torch.float8_e4m3fn`.
-            - A tensor of scaling factors with dtype `torch.float32`.
-    """
-    assert x.is_contiguous(), "Input tensor must be contiguous"
-    assert (
-        x.size(-1) % block_size == 0
-    ), f"Last dimension size must be divisible by block_size (block_size={block_size})"
-    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
-    s = x.new_empty(*x.size()[:-1], x.size(-1) // block_size, dtype=torch.float32)
-    grid = lambda meta: (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)
-    act_quant_kernel[grid](x, y, s, BLOCK_SIZE=block_size, FP8_MAX=FP8_MAX)
     return y, s
 
 
@@ -292,7 +239,7 @@ def calculate_diff(m, dummy):
     end_event.record()
     torch.cuda.synchronize()
     triton_ref_time = (time.time() - start) / iters * 1000
-    triton_ref_device_elapsed = start_event.elapsed_time(end_event) / iters        
+    triton_ref_device_elapsed = start_event.elapsed_time(end_event) / iters
 
     # === ThunderMuon Symm Gemm - baseline (CUDA) ===
     symm_gemm_op = GluonXXT()

--- a/benchmark/moun/bench_triton_3_5_cuda_symm_gemm.py
+++ b/benchmark/moun/bench_triton_3_5_cuda_symm_gemm.py
@@ -1,0 +1,449 @@
+import itertools
+import os
+import time
+from typing import Any, Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+import triton.testing
+
+from jit_kernel.thunder_moun import symm_gemm_block_scaled
+
+# TODO (yiakwy) : remove the reference
+from jit_kernel.triton3_5.symm_gemm import XXT, XTX
+
+from jit_kernel.triton3_5.gluon.symm_gemm import GluonXXT
+
+SEED = 42
+
+# CI environment detection
+IS_CI = (
+    os.getenv("CI", "false").lower() == "true"
+    or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+)
+
+
+OCP_FP8E4M3_MAX = 448.0
+FP8_MAX = OCP_FP8E4M3_MAX
+
+
+DEBUG = False
+
+
+@triton.jit
+def fp8_weight_block_wise_quant_kernel(
+    x_ptr,
+    y_ptr,
+    s_ptr,
+    M,
+    N,
+    SCALED_BLOCK_SIZE_M: tl.constexpr,
+    SCALED_BLOCK_SIZE_N: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    n = tl.cdiv(N, SCALED_BLOCK_SIZE_M)
+    offs_m = pid_m * SCALED_BLOCK_SIZE_M + tl.arange(0, SCALED_BLOCK_SIZE_M)
+    offs_n = pid_n * SCALED_BLOCK_SIZE_N + tl.arange(0, SCALED_BLOCK_SIZE_N)
+    offs = offs_m[:, None] * N + offs_n[None, :]
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
+    s = tl.max(tl.abs(x)) / FP8_MAX
+    y = x / s
+    y = y.to(y_ptr.dtype.element_ty)
+    tl.store(y_ptr + offs, y, mask=mask)
+    tl.store(s_ptr + pid_m * n + pid_n, s)
+
+
+def fp8_weight_block_wise_quant(
+    x: torch.Tensor, scaled_block_size_m: int = 128, scaled_block_size_n: int = 128
+):
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert x.dim() == 2, "Input tensor must have 2 dimensions"
+    # assert x.size(0) % scaled_block_size_m == 0 and x.size(1) % scaled_block_size_n == 0, \
+    #     f"Dimensions of x must be divisible by scaled block_size (scale_block_size_m={scaled_block_size_m}x{scaled_block_size_n})"
+    M, N = x.size()
+    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    s = x.new_empty(
+        triton.cdiv(M, scaled_block_size_m),
+        triton.cdiv(N, scaled_block_size_n),
+        dtype=torch.float32,
+    )
+    grid = lambda meta: (
+        triton.cdiv(M, meta["SCALED_BLOCK_SIZE_M"]),
+        triton.cdiv(N, meta["SCALED_BLOCK_SIZE_N"]),
+    )
+    fp8_weight_block_wise_quant_kernel[grid](
+        x,
+        y,
+        s,
+        M,
+        N,
+        SCALED_BLOCK_SIZE_M=scaled_block_size_m,
+        SCALED_BLOCK_SIZE_N=scaled_block_size_n,
+        FP8_MAX=FP8_MAX,
+    )
+    return y, s
+
+
+@triton.jit
+def act_quant_kernel(
+    x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr, FP8_MAX: tl.constexpr
+):
+    """
+    Quantizes the input tensor `x_ptr` and stores the result in `y_ptr` and the scaling factor in `s_ptr`.
+
+    Args:
+        x_ptr (triton.Pointer): Pointer to the input tensor.
+        y_ptr (triton.Pointer): Pointer to the output tensor where quantized values will be stored.
+        s_ptr (triton.Pointer): Pointer to the output tensor where scaling factors will be stored.
+        BLOCK_SIZE (tl.constexpr): The size of the block to be processed by each program instance.
+
+    Returns:
+        None
+    """
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    x = tl.load(x_ptr + offs).to(tl.float32)
+    s = tl.max(tl.abs(x)) / FP8_MAX
+    y = x / s
+    y = y.to(y_ptr.dtype.element_ty)
+    tl.store(y_ptr + offs, y)
+    tl.store(s_ptr + pid, s)
+
+
+def act_quant(
+    x: torch.Tensor, block_size: int = 128
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantizes the input tensor `x` using block-wise quantization.
+
+    Args:
+        x (torch.Tensor): The input tensor to be quantized. Must be contiguous and its last dimension size must be divisible by `block_size`.
+        block_size (int, optional): The size of the blocks to be used for quantization. Default is 128.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
+            - The quantized tensor with dtype `torch.float8_e4m3fn`.
+            - A tensor of scaling factors with dtype `torch.float32`.
+    """
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert (
+        x.size(-1) % block_size == 0
+    ), f"Last dimension size must be divisible by block_size (block_size={block_size})"
+    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    s = x.new_empty(*x.size()[:-1], x.size(-1) // block_size, dtype=torch.float32)
+    grid = lambda meta: (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)
+    act_quant_kernel[grid](x, y, s, BLOCK_SIZE=block_size, FP8_MAX=FP8_MAX)
+    return y, s
+
+
+@triton.jit
+def act_quant_kernel(
+    x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr, FP8_MAX: tl.constexpr
+):
+    """
+    Quantizes the input tensor `x_ptr` and stores the result in `y_ptr` and the scaling factor in `s_ptr`.
+
+    Args:
+        x_ptr (triton.Pointer): Pointer to the input tensor.
+        y_ptr (triton.Pointer): Pointer to the output tensor where quantized values will be stored.
+        s_ptr (triton.Pointer): Pointer to the output tensor where scaling factors will be stored.
+        BLOCK_SIZE (tl.constexpr): The size of the block to be processed by each program instance.
+
+    Returns:
+        None
+    """
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    x = tl.load(x_ptr + offs).to(tl.float32)
+    s = tl.max(tl.abs(x)) / FP8_MAX
+    y = x / s
+    y = y.to(y_ptr.dtype.element_ty)
+    tl.store(y_ptr + offs, y)
+    tl.store(s_ptr + pid, s)
+
+
+def act_quant(
+    x: torch.Tensor, block_size: int = 128
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantizes the input tensor `x` using block-wise quantization.
+
+    Args:
+        x (torch.Tensor): The input tensor to be quantized. Must be contiguous and its last dimension size must be divisible by `block_size`.
+        block_size (int, optional): The size of the blocks to be used for quantization. Default is 128.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
+            - The quantized tensor with dtype `torch.float8_e4m3fn`.
+            - A tensor of scaling factors with dtype `torch.float32`.
+    """
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert (
+        x.size(-1) % block_size == 0
+    ), f"Last dimension size must be divisible by block_size (block_size={block_size})"
+    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    s = x.new_empty(*x.size()[:-1], x.size(-1) // block_size, dtype=torch.float32)
+    grid = lambda meta: (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)
+    act_quant_kernel[grid](x, y, s, BLOCK_SIZE=block_size, FP8_MAX=FP8_MAX)
+    return y, s
+
+
+def calculate_diff(m, dummy):
+    torch.manual_seed(SEED)
+
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    x = torch.arange(m, dtype=torch.float16, device="cuda").view(1, -1) / (
+        m - 1
+    ) + torch.arange(m, dtype=torch.float16, device="cuda").view(-1, 1) / (m - 1)
+    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device="cuda")
+    xs_1 = torch.ones(
+        (triton.cdiv(m, 128), triton.cdiv(m, 128)), dtype=torch.float32, device="cuda"
+    )
+
+    xq = x
+    wq = x
+
+    # x = torch.randn(m, m, dtype=torch.float16, device='cuda')
+
+    # xq, xs_0 = act_quant(x)
+    # wq, xs_1 = fp8_weight_block_wise_quant(x)
+
+    xq_fp8 = xq.to(torch.float8_e4m3fn)
+    wq_fp8 = wq.to(torch.float8_e4m3fn)
+
+    # print("x : ", x)
+    # print("xq : ", xq)
+    # print("xq_fp8 : ", xq_fp8)
+
+    print("x.shape : ", x.shape)
+    print("xs_0.shape : ", xs_0.shape)
+    print("xs_1.shape : ", xs_1.shape)
+
+    o_torch_ref = (x @ x.T).cpu()
+
+    print("o_torch_ref : ", o_torch_ref)
+
+    symm_gemm_op = GluonXXT()
+    o_gluon_ref = symm_gemm_op(x).cpu()
+
+    print("g_gluon_ref : ", o_gluon_ref)
+
+    diff = o_torch_ref - o_gluon_ref
+    print("diff (gluon tma ref): ", diff)
+    torch.testing.assert_close(o_gluon_ref, o_torch_ref, rtol=5e-01, atol=1e-03)
+
+    o_symm_fp8_tril = symm_gemm_block_scaled(
+        xq.to(torch.float8_e4m3fn), wq.to(torch.float8_e4m3fn), xs_0, xs_1
+    ).cpu()
+
+    print("o_symm_fp8_tril (cuda symm) : ", o_symm_fp8_tril)
+
+    diff = o_torch_ref - o_symm_fp8_tril
+    print("diff (cuda symm): ", diff)
+    # print("diff 0 (cuda symm): ", diff[0:8,0:8])
+    # print("diff 1 (cuda symm): ", diff[0:9,0:9])
+
+    torch.testing.assert_close(o_symm_fp8_tril, o_torch_ref, rtol=5e-01, atol=1e-03)
+
+    print(f"✅ {m}x{m}x{m} thunder_moun_gemm")
+    torch.cuda.synchronize()
+
+    if DEBUG:
+        return
+
+    warmup = 25
+    iters = 100
+    for _ in range(warmup):
+        _ = x @ x.T
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    for _ in range(iters):
+        _ = x @ x.T
+    end_event.record()
+    torch.cuda.synchronize()
+    torch_time = (time.time() - start) / iters * 1000
+    torch_device_elapsed = start_event.elapsed_time(end_event) / iters
+
+    # TODO (yiakwy) : add test wrapper
+
+    # === modded-gpt XXT - baseline (triton ref) ===
+    for _ in range(warmup):
+        _ = XXT(x)
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    for _ in range(iters):
+        _ = XXT(x)
+    end_event.record()
+    torch.cuda.synchronize()
+    triton_ref_time = (time.time() - start) / iters * 1000
+    triton_ref_device_elapsed = start_event.elapsed_time(end_event) / iters        
+
+    # === ThunderMuon Symm Gemm - baseline (CUDA) ===
+    symm_gemm_op = GluonXXT()
+
+    for _ in range(warmup):
+        _ = symm_gemm_op(x)
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    for _ in range(iters):
+        _ = symm_gemm_op(x)
+    end_event.record()
+    torch.cuda.synchronize()
+
+    gluon_ref_time = (time.time() - start) / iters * 1000
+    gluon_ref_device_elapsed = start_event.elapsed_time(end_event) / iters
+
+    # === ThunderMuon Symm Gemm - baseline (CUDA) ===
+    for _ in range(warmup):
+        _ = symm_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1)
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    for _ in range(iters):
+        o_symm_fp8_tril = symm_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1)
+    end_event.record()
+    torch.cuda.synchronize()
+    symm_gemm_time = (time.time() - start) / iters * 1000
+    symm_gemm_device_elapsed = start_event.elapsed_time(end_event) / iters
+
+    print(f"\nPerformance:")
+    print(
+        f"PyTorch                      : {torch_time:.3f} ms, device {torch_device_elapsed:.3f} ms"
+    )
+    print(
+        f"Triton ref kernel             : {triton_ref_time:.3f} ms, device {triton_ref_device_elapsed:.3f} ms"
+    )
+    print(
+        f"Gluon TMA kernel             : {gluon_ref_time:.3f} ms, device {gluon_ref_device_elapsed:.3f} ms"
+    )
+    print(
+        f"Cuda Muon Symm Gemm          : {symm_gemm_time:.3f} ms, device {symm_gemm_device_elapsed:.3f} ms"
+    )
+    print(
+        f"Speedup (cuda symm V3)       : {torch_time/symm_gemm_time:.2f}x, {torch_device_elapsed / symm_gemm_device_elapsed:.2f}x"
+    )
+
+
+M = [2048, 4096, 8192]
+dummy = [1]
+
+configs = list(itertools.product(M, dummy))
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["m", "dummy"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=[
+            "torch",
+            "triton_impl_ref",
+            "gluon_muon_symm_gemm",
+            "cuda_muon_symm_gemm",
+        ],
+        line_names=[
+            "torch",
+            "triton_muon_symm_gemm_ref",
+            "gluon_muon_symm_gemm",
+            "cuda_muon_symm_gemm (not optimized)",
+        ],
+        styles=[
+            ("red", "-"),
+            ("blue", "-"),
+            ("green", "-"),
+            ("orange", "-"),
+            ("purple", "-"),
+        ],
+        ylabel="Latency",
+        plot_name="muon-symm-gemm-performance",
+        args={},
+    )
+)
+def benchmark(m: int, dummy: int, provider) -> None:
+    torch.manual_seed(SEED)
+
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    # x = torch.arange(256, dtype=torch.float16, device='cuda').view(1, -1) / 255.0 + torch.arange(256, dtype=torch.float16, device='cuda').view(-1, 1) / 255.0
+
+    x = torch.randn(m, m, dtype=torch.bfloat16, device="cuda")
+    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device="cuda")
+    xs_1 = torch.ones(
+        (triton.cdiv(m, 128), triton.cdiv(m, 128)), dtype=torch.float32, device="cuda"
+    )
+
+    xq = x
+    wq = x
+
+    # NOTE (yiakwy) : this can be computed asynchronously before Muon update
+    # xq, xs_0 = act_quant(x)
+    # wq, xs_1 = fp8_weight_block_wise_quant(x)
+
+    x_fp8 = xq.to(torch.float8_e4m3fn)
+    wq_fp8 = wq.to(torch.float8_e4m3fn)
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    symm_gemm_op = GluonXXT()
+
+    if provider == "torch":
+        fn = lambda: x @ x.T
+    elif provider == "triton_impl_ref":
+        fn = lambda: XXT(x)
+    elif provider == "gluon_muon_symm_gemm":
+        fn = lambda: symm_gemm_op(x)
+    elif provider == "cuda_muon_symm_gemm":
+        fn = lambda: symm_gemm_block_scaled(x_fp8, wq_fp8, xs_0, xs_1)
+
+    # warm up
+    for _ in range(10):
+        fn()
+    torch.cuda.synchronize()
+
+    ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
+
+    return ms * 1000, min_ms * 1000, max_ms * 1000
+
+
+if __name__ == "__main__":
+    # Correctness check - simplified for CI
+    if IS_CI:
+        # Only test one configuration in CI
+        test_configs = [configs[0]]
+    else:
+        test_configs = configs
+
+    for cfg in test_configs:
+        print(f"cfg : {cfg}")
+        calculate_diff(*cfg)
+
+    print("\n" + "=" * 60)
+    if not DEBUG:
+        print("Starting performance benchmark...")
+        benchmark.run(print_data=True)

--- a/jit_kernel/triton3_4/symm_gemm.py
+++ b/jit_kernel/triton3_4/symm_gemm.py
@@ -70,7 +70,7 @@ def _remmap_pid(tile_id, tall_xcds, BLOCKS_PER_XCD, NUM_XCDS):
     return tile_id
 
 
-# see our paper
+# NOTE (yiakwy) : see our paper for cuda kernel for swizzle of lower left triangle
 # pid = pid_m * (pid_m + 1) / 2 + pid_n
 # pid_m*2 + pid_m - 2*pid - pid_n = 0
 @triton.jit

--- a/jit_kernel/triton3_4/test_tvm_ffi_triton.py
+++ b/jit_kernel/triton3_4/test_tvm_ffi_triton.py
@@ -1,6 +1,7 @@
-import torch, triton
-import jit_kernel.triton3_4.symm_gemm as s
+import torch
+import triton
 
+import jit_kernel.triton3_4.symm_gemm as s
 
 SEED = 42
 
@@ -25,24 +26,38 @@ def test(m=2048):
 
     out = torch.empty((m, m), dtype=torch.float16, device="cuda")
 
-    sentinel = -1234.0
+    sentinel = float("NaN")
 
     # first call: populate TVM-FFI cache
     print("first call : ...")
     out.fill_(sentinel)
+    torch.cuda.synchronize()
+
     s.thunder_moun_gemm(x_fp8, x_fp8, xs_0, xs_1, out=out)
     torch.cuda.synchronize()
-    print("first sentinel remaining:", (out == sentinel).sum().item())
+    remaining = (out == sentinel).sum().item()
+    print("[1st Write] sentinel remaining:", remaining)
+
+    assert (
+        remaining == 0
+    ), f"[1st Write] Expected kernel to overwrite all elements, but {remaining} remained sentinel"
+
+    sentinel = float("-1234")
 
     # second call: cached TVM-FFI path only
     print("second call : ...")
     out.fill_(sentinel)
+    torch.cuda.synchronize()
+
     s.thunder_moun_gemm(x_fp8, x_fp8, xs_0, xs_1, out=out)
     torch.cuda.synchronize()
     remaining = (out == sentinel).sum().item()
 
-    print("cached sentinel remaining:", remaining)
-    print("total elements:", out.numel())
+    print("[2rd Write], sentinel remaining:", remaining)
+
+    assert (
+        remaining == 0
+    ), f"[2rd Write] Expected kernel to overwrite all elements, but {remaining} remained sentinel"
 
 
 if __name__ == "__main__":

--- a/jit_kernel/triton3_4/test_tvm_ffi_triton.py
+++ b/jit_kernel/triton3_4/test_tvm_ffi_triton.py
@@ -1,0 +1,49 @@
+import torch, triton
+import jit_kernel.triton3_4.symm_gemm as s
+
+
+SEED = 42
+
+
+def test(m=2048):
+
+    torch.manual_seed(SEED)
+
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    xq = torch.arange(m, dtype=torch.float16, device="cuda").view(1, -1) / (
+        m - 1
+    ) + torch.arange(m, dtype=torch.float16, device="cuda").view(-1, 1) / (m - 1)
+
+    x_fp8 = xq.to(torch.float8_e4m3fn)
+
+    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device="cuda")
+    xs_1 = torch.ones(
+        (triton.cdiv(m, 128), triton.cdiv(m, 128)), dtype=torch.float32, device="cuda"
+    )
+
+    out = torch.empty((m, m), dtype=torch.float16, device="cuda")
+
+    sentinel = -1234.0
+
+    # first call: populate TVM-FFI cache
+    print("first call : ...")
+    out.fill_(sentinel)
+    s.thunder_moun_gemm(x_fp8, x_fp8, xs_0, xs_1, out=out)
+    torch.cuda.synchronize()
+    print("first sentinel remaining:", (out == sentinel).sum().item())
+
+    # second call: cached TVM-FFI path only
+    print("second call : ...")
+    out.fill_(sentinel)
+    s.thunder_moun_gemm(x_fp8, x_fp8, xs_0, xs_1, out=out)
+    torch.cuda.synchronize()
+    remaining = (out == sentinel).sum().item()
+
+    print("cached sentinel remaining:", remaining)
+    print("total elements:", out.numel())
+
+
+if __name__ == "__main__":
+    test()

--- a/jit_kernel/triton3_4/tvm_ffi_mod.py
+++ b/jit_kernel/triton3_4/tvm_ffi_mod.py
@@ -1,17 +1,20 @@
+import inspect
+
 import triton
-
-import tvm_ffi
-
+import triton.language as tl
 from packaging import version
 
-import inspect
-import triton.language as tl
 
 def is_constexpr_param(param):
     ann = param.annotation
     if ann is inspect._empty:
         return False
-    return ann is tl.constexpr or getattr(ann, "__name__", "") == "constexpr" or "constexpr" in str(ann)
+    return (
+        ann is tl.constexpr
+        or getattr(ann, "__name__", "") == "constexpr"
+        or "constexpr" in str(ann)
+    )
+
 
 def cpp_host_type(name: str) -> str:
     if "ptr" in name:
@@ -28,49 +31,40 @@ def kernel_arg_type(name: str) -> str:
         return "bool"
     return "int32_t"
 
+
 def kernel_arg_assignment(name: str) -> str:
     if "ptr" in name:
         return f"kargs.{name} = {name}.data_ptr();\n"
     return f"kargs.{name} = {name};\n"
 
-def runtime_arg_decl(name: str) -> str:
-    var = f"{name}_arg"
-    if "ptr" in name:
-        return f"void* {var} = {name}.data_ptr();\n"
-    if "use_" in name or "is_" in name:
-        return f"bool {var} = {name};\n"
-    return f"int32_t {var} = {name};\n"
 
 # Triton 3.4
 def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
     # Triton 3.5+
     if version.parse(triton.__version__) >= version.parse("3.5"):
-        raise Exception("TVM FFI Not Implemented for Triton 3.5+ due to the change of metadata structure, need to update the parsing logic accordingly.")
-    
+        raise Exception(
+            "TVM FFI Not Implemented for Triton 3.5+ due to the change of metadata structure, need to update the parsing logic accordingly."
+        )
+
     if debug:
         print(compiled_kernel.metadata)
         print(compiled_kernel.asm["ptx"].split(".entry", 1)[1].split(")", 1)[0])
 
     arg_names = compiled_kernel.src.fn.arg_names
-    signature = compiled_kernel.src.fn.signature 
+    signature = compiled_kernel.src.fn.signature
 
-    # cpp_params = ["int64_t cubin_ptr_addr"]   # FFI args list
+    # TVM-FFI args list
     cpp_params = []
-    cpp_arg_names = []
 
-    launch_args_def = []  # cuLaunchKernel pointer args list
-    launch_args = []  # cuLaunchKernel args list
-    launch_arg_names = []
+    # cuLaunchKernel arguemnt definition
+    launch_args_def = []
+    # cuLaunchKernel argsument assignment
+    launch_args = []
 
     constants = {}
     constants_set = set()
     for key, val in compiled_kernel.src.constants.items():
         name = arg_names[key[0]]
-
-        # if "stride_" in name:
-        #     if debug:
-        #         print(f"{name} is not regarded as constant")
-        #     continue
 
         constants[name] = (key[0], val)
         constants_set.add(name)
@@ -80,48 +74,23 @@ def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
         print("constants : ", constants)
 
     for name, param in signature.parameters.items():
+        # const param should not be added into cpp_params
         if is_constexpr_param(param):
             continue
 
-        cpp_arg_names.append(name)
+        cpp_params.append(f"{cpp_host_type(name)} {name}")
 
+        # const in a compiled kernel should not be added into launch_args_def and launch_args
         if name not in constants_set:
-            launch_arg_names.append(name)
-            
-    cpp_params = [f"{cpp_host_type(name)} {name}" for name in cpp_arg_names]
-    cpp_params_str = ", ".join(cpp_params + ["int32_t grid_x", "int32_t grid_y", "int32_t grid_z"])
-    
-    launch_args_def = [
-        f"{kernel_arg_type(name)} {name};\n"
-        for name in launch_arg_names
-    ]
+            launch_args_def.append(f"{kernel_arg_type(name)} {name};\n")
+            launch_args.append(kernel_arg_assignment(name))
 
-    launch_args = [
-        kernel_arg_assignment(name)
-        for name in launch_arg_names
-    ]
-    
-    launch_args_def.append("CUdeviceptr global_scratch;\n")
-    launch_args.append("kargs.global_scratch = 0;\n")
+    cpp_params_str = ", ".join(
+        cpp_params + ["int32_t grid_x", "int32_t grid_y", "int32_t grid_z"]
+    )
 
     launch_args_def_str = "".join(launch_args_def)
     launch_args_str = "".join(launch_args)
-    
-    runtime_arg_decls = [
-        runtime_arg_decl(name)
-        for name in launch_arg_names
-    ]
-
-    runtime_arg_ptrs = [
-        f"&{name}_arg"
-        for name in launch_arg_names
-    ]
-
-    runtime_arg_decls.append("CUdeviceptr global_scratch_arg = 0;\n")
-    runtime_arg_ptrs.append("&global_scratch_arg")
-
-    runtime_arg_decls_str = "".join(runtime_arg_decls)
-    runtime_arg_ptrs_str = ",\n        ".join(runtime_arg_ptrs)
 
     if debug:
         print(f"cpp_params_str : {cpp_params_str}")
@@ -129,14 +98,10 @@ def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
         print(f"launch_args_str : {launch_args_str}")
 
     META = compiled_kernel.metadata
-    
-    global_scratch_size = getattr(META, "global_scratch_size", 0)
-    global_scratch_align = getattr(META, "global_scratch_align", 1)
 
-    num_warps = META.num_warps # compiled_kernel.num_warps
+    num_warps = META.num_warps  # compiled_kernel.num_warps
     shared_mem_size = META.shared
 
-    arch = META.target.arch
     WARP_SIZE = META.target.warp_size
 
     source = f"""
@@ -149,14 +114,46 @@ def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
 #include <cuda_runtime.h>
 #include <cuda.h>
 
-#define USE_TVM_FFI_LAUNCH_CONVENTION 0
+
+// NOTE (yiakwy) : for CUresult
+#define CHECK_CUDA_DRIVER_ERROR(call) \
+    do {{ \
+        CUresult err = call; \
+        if (err != CUDA_SUCCESS) {{ \
+            const char *err_name, *err_str; \
+            cuGetErrorName(err, &err_name); \
+            cuGetErrorString(err, &err_str); \
+            fprintf(stderr, "CUDA Driver Error at %s:%d: %s (%s)\\n", \
+                    __FILE__, __LINE__, err_name, err_str); \
+            fprintf(stderr, "Error code: %d\\n", err); \
+            cuCtxSynchronize(); \
+            throw std::runtime_error(std::string(err_name) + ", " + err_str); \
+        }} \
+    }} while(0)
+
+
+#define CHECK_CUDA_RUNTIME_ERROR(call) \
+    do {{ \
+        cudaError_t err = call; \
+        if (err != cudaSuccess) {{ \
+            const char *err_name, *err_str; \
+            err_name = cudaGetErrorName(err); \
+            err_str = cudaGetErrorString(err); \
+            fprintf(stderr, "CUDA Runtime Error at %s:%d: %s (%s)\\n", \
+                    __FILE__, __LINE__, err_name, err_str); \
+            fprintf(stderr, "Error code: %d\\n", err); \
+            cudaDeviceSynchronize(); \
+            throw std::runtime_error(std::string(err_name) + ", " + err_str); \
+        }} \
+    }} while(0)
+
 
 TVM_FFI_EMBED_CUBIN(triton_cubin);
 
 namespace triton_loader {{
 using namespace tvm::ffi;
 
-// NOTE (yiakwy) : TVM's official method does not handle alignment issue, hence I use this method to escape alignment problem. 
+// NOTE (yiakwy) : TVM's official method does not handle alignment issue, hence I use this method to escape alignment problem.
 // We can also consider to modify TVM's official method to support alignment in the future if necessary.
 struct KernelArgs {{
     {launch_args_def_str};
@@ -169,106 +166,53 @@ void {kernel_name}_launcher({cpp_params_str}) {{
     KernelArgs kargs;
 
     {launch_args_str};
-    
-    //runtime-api
-    {runtime_arg_decls_str}
 
-    void* args[] = {{
-            {runtime_arg_ptrs_str}
-    }};
-        
-    cudaGetLastError();
+    DLDevice device = {arg_names[0]}.device();
 
     int shared_mem_bytes = {shared_mem_size};
-    // cuDeviceGetAttribute(&shared_mem_bytes, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, 0);
-    
-    auto kernel = launcher.GetHandle();
-    // CUfunction kernel = *(reinterpret_cast<CUfunction*>(&launcher));
-    // CUresult attr_result = cuFuncSetAttribute(kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (unsigned int)shared_mem_bytes);
-    
-    /* 
-    if (attr_result != CUDA_SUCCESS) {{
-        TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
-            static_cast<::tvm::ffi::cuda_api::ResultType>(attr_result)
-        );
+    shared_mem_bytes = (shared_mem_bytes + 7) & ~7;
+
+    // NOTE (yiakwy) : use CUDA driver api
+    int max_shared_mem_bytes;
+    CUresult get_attr_result = cuDeviceGetAttribute(&max_shared_mem_bytes, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, device.device_id);
+    CHECK_CUDA_DRIVER_ERROR(get_attr_result);
+
+    // NOTE (yiakwy) : Hopper allows to set maximum share memory >= 483232 bytes
+    if (shared_mem_bytes > max_shared_mem_bytes) {{
+        max_shared_mem_bytes = shared_mem_bytes;
     }}
-    */
-    
-    DLDevice device = {arg_names[0]}.device();
-    
-    ::tvm::ffi::cuda_api::StreamHandle stream =
-        static_cast<::tvm::ffi::cuda_api::StreamHandle>(
-            TVMFFIEnvGetStream(device.device_type, device.device_id));
 
-    auto device_handle =
-        ::tvm::ffi::cuda_api::GetDeviceHandle(device.device_id);
+    CUfunction kernel = *(reinterpret_cast<CUfunction*>(&launcher));
 
-    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
-        ::tvm::ffi::cuda_api::SetKernelMaxDynamicSharedMem(
-            kernel,
-            shared_mem_bytes,
-            device_handle)
-    );
-    
-    // cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
+    // NOTE (yiakwy) : use cuda runtime api
+    cudaError_t set_attr_result = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem_bytes);
+    CHECK_CUDA_RUNTIME_ERROR(set_attr_result);
+
+    cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
 
     tvm::ffi::dim3 grid((unsigned int)grid_x, (unsigned int)grid_y, (unsigned int)grid_z);
     tvm::ffi::dim3 block({num_warps * WARP_SIZE}, 1, 1);
 
-#if USE_TVM_FFI_LAUNCH_CONVENTION
-    // Launch Kernel : old version does not support to pass shared_mem_bytes, so here is my workaround
-    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(launcher.Launch(args, grid, block, stream, shared_mem_bytes));
-
-
-#else
-    // see https://github.com/apache/tvm-ffi/blob/d73a26783488430986fd855ae67ff7a9fb016413/include/tvm/ffi/extra/cuda/internal/unified_api.h#L115
-    /*  
-    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(
-        cuLaunchKernel(kernel, 
-          grid.x, grid.y, grid.z, 
-          block.x, block.y, block.z, 
-          (unsigned int)shared_mem_bytes, stream, nullptr, config);
-    ));
-    */
-
-
-#if TVM_FFI_CUBIN_LAUNCHER_USE_DRIVER_API
     size_t kargs_size = sizeof(KernelArgs);
     void* config[] = {{
         CU_LAUNCH_PARAM_BUFFER_POINTER, &kargs,
         CU_LAUNCH_PARAM_BUFFER_SIZE,    &kargs_size,
         CU_LAUNCH_PARAM_END
-    }};  
+    }};
 
     CUresult result = cuLaunchKernel(
-          reinterpret_cast<CUfunction>(kernel), 
-          grid.x, grid.y, grid.z, 
-          block.x, block.y, block.z, 
+          kernel,
+          grid.x, grid.y, grid.z,
+          block.x, block.y, block.z,
           (unsigned int)shared_mem_bytes, stream, nullptr, config);
 
-    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(result);
-#else
-    cudaError_t result = cudaLaunchKernel(
-        reinterpret_cast<const void*>(kernel),
-        ::dim3(grid.x, grid.y, grid.z),
-        ::dim3(block.x, block.y, block.z),
-        args,
-        (size_t)shared_mem_bytes,
-        stream);
-
-    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(result);
-#endif
-
     if (result != CUDA_SUCCESS) {{
-        TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(result));
+        CHECK_CUDA_DRIVER_ERROR(result);
     }}
-
-    // cudaDeviceSynchronize();
-#endif
 }}
 
 }} // namespace triton_loader
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC({kernel_name}, triton_loader::{kernel_name}_launcher);
 """
-    return source, constants 
+    return source, constants

--- a/jit_kernel/triton3_4/tvm_ffi_mod.py
+++ b/jit_kernel/triton3_4/tvm_ffi_mod.py
@@ -4,30 +4,73 @@ import tvm_ffi
 
 from packaging import version
 
+import inspect
+import triton.language as tl
+
+def is_constexpr_param(param):
+    ann = param.annotation
+    if ann is inspect._empty:
+        return False
+    return ann is tl.constexpr or getattr(ann, "__name__", "") == "constexpr" or "constexpr" in str(ann)
+
+def cpp_host_type(name: str) -> str:
+    if "ptr" in name:
+        return "TensorView"
+    if "use_" in name or "is_" in name:
+        return "bool"
+    return "int32_t"
+
+
+def kernel_arg_type(name: str) -> str:
+    if "ptr" in name:
+        return "void*"
+    if "use_" in name or "is_" in name:
+        return "bool"
+    return "int32_t"
+
+def kernel_arg_assignment(name: str) -> str:
+    if "ptr" in name:
+        return f"kargs.{name} = {name}.data_ptr();\n"
+    return f"kargs.{name} = {name};\n"
+
+def runtime_arg_decl(name: str) -> str:
+    var = f"{name}_arg"
+    if "ptr" in name:
+        return f"void* {var} = {name}.data_ptr();\n"
+    if "use_" in name or "is_" in name:
+        return f"bool {var} = {name};\n"
+    return f"int32_t {var} = {name};\n"
+
 # Triton 3.4
 def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
     # Triton 3.5+
     if version.parse(triton.__version__) >= version.parse("3.5"):
         raise Exception("TVM FFI Not Implemented for Triton 3.5+ due to the change of metadata structure, need to update the parsing logic accordingly.")
     
+    if debug:
+        print(compiled_kernel.metadata)
+        print(compiled_kernel.asm["ptx"].split(".entry", 1)[1].split(")", 1)[0])
+
     arg_names = compiled_kernel.src.fn.arg_names
     signature = compiled_kernel.src.fn.signature 
 
     # cpp_params = ["int64_t cubin_ptr_addr"]   # FFI args list
     cpp_params = []
+    cpp_arg_names = []
 
     launch_args_def = []  # cuLaunchKernel pointer args list
     launch_args = []  # cuLaunchKernel args list
+    launch_arg_names = []
 
     constants = {}
     constants_set = set()
     for key, val in compiled_kernel.src.constants.items():
         name = arg_names[key[0]]
 
-        if "stride_" in name:
-            if debug:
-                print(f"{name} is not regarded as constant")
-            continue
+        # if "stride_" in name:
+        #     if debug:
+        #         print(f"{name} is not regarded as constant")
+        #     continue
 
         constants[name] = (key[0], val)
         constants_set.add(name)
@@ -37,27 +80,48 @@ def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
         print("constants : ", constants)
 
     for name, param in signature.parameters.items():
-        if name in constants_set:
+        if is_constexpr_param(param):
             continue
 
-        if "ptr" in name:
-            cpp_params.append(f"TensorView {name}")
-            launch_args_def.append(f"void* {name};\n")
-            launch_args.append(f"kargs.{name} = {name}.data_ptr();\n")
-        elif "use_" in name or "is_" in name:
-            cpp_params.append(f"bool {name}")
-            launch_args_def.append(f"bool {name};\n")
-            launch_args.append(f"kargs.{name} = {name};\n")
-        else:
-            cpp_params.append(f"int32_t {name}")
-            launch_args_def.append(f"int32_t {name};\n")
-            launch_args.append(f"kargs.{name} = {name};\n")
-            
+        cpp_arg_names.append(name)
 
+        if name not in constants_set:
+            launch_arg_names.append(name)
+            
+    cpp_params = [f"{cpp_host_type(name)} {name}" for name in cpp_arg_names]
     cpp_params_str = ", ".join(cpp_params + ["int32_t grid_x", "int32_t grid_y", "int32_t grid_z"])
+    
+    launch_args_def = [
+        f"{kernel_arg_type(name)} {name};\n"
+        for name in launch_arg_names
+    ]
+
+    launch_args = [
+        kernel_arg_assignment(name)
+        for name in launch_arg_names
+    ]
+    
+    launch_args_def.append("CUdeviceptr global_scratch;\n")
+    launch_args.append("kargs.global_scratch = 0;\n")
 
     launch_args_def_str = "".join(launch_args_def)
     launch_args_str = "".join(launch_args)
+    
+    runtime_arg_decls = [
+        runtime_arg_decl(name)
+        for name in launch_arg_names
+    ]
+
+    runtime_arg_ptrs = [
+        f"&{name}_arg"
+        for name in launch_arg_names
+    ]
+
+    runtime_arg_decls.append("CUdeviceptr global_scratch_arg = 0;\n")
+    runtime_arg_ptrs.append("&global_scratch_arg")
+
+    runtime_arg_decls_str = "".join(runtime_arg_decls)
+    runtime_arg_ptrs_str = ",\n        ".join(runtime_arg_ptrs)
 
     if debug:
         print(f"cpp_params_str : {cpp_params_str}")
@@ -65,9 +129,12 @@ def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
         print(f"launch_args_str : {launch_args_str}")
 
     META = compiled_kernel.metadata
+    
+    global_scratch_size = getattr(META, "global_scratch_size", 0)
+    global_scratch_align = getattr(META, "global_scratch_align", 1)
 
     num_warps = META.num_warps # compiled_kernel.num_warps
-    shared_mem_size = 24 * 1024 # META.shared
+    shared_mem_size = META.shared
 
     arch = META.target.arch
     WARP_SIZE = META.target.warp_size
@@ -80,6 +147,7 @@ def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
 #include <tvm/ffi/error.h>
 #include <tvm/ffi/extra/c_env_api.h>
 #include <cuda_runtime.h>
+#include <cuda.h>
 
 #define USE_TVM_FFI_LAUNCH_CONVENTION 0
 
@@ -102,16 +170,47 @@ void {kernel_name}_launcher({cpp_params_str}) {{
 
     {launch_args_str};
     
+    //runtime-api
+    {runtime_arg_decls_str}
+
+    void* args[] = {{
+            {runtime_arg_ptrs_str}
+    }};
+        
     cudaGetLastError();
 
     int shared_mem_bytes = {shared_mem_size};
-    cuDeviceGetAttribute(&shared_mem_bytes, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, 0);
+    // cuDeviceGetAttribute(&shared_mem_bytes, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, 0);
     
-    CUfunction kernel = *(reinterpret_cast<CUfunction*>(&launcher));
-    cuFuncSetAttribute(kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (unsigned int)shared_mem_bytes);
+    auto kernel = launcher.GetHandle();
+    // CUfunction kernel = *(reinterpret_cast<CUfunction*>(&launcher));
+    // CUresult attr_result = cuFuncSetAttribute(kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (unsigned int)shared_mem_bytes);
+    
+    /* 
+    if (attr_result != CUDA_SUCCESS) {{
+        TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
+            static_cast<::tvm::ffi::cuda_api::ResultType>(attr_result)
+        );
+    }}
+    */
     
     DLDevice device = {arg_names[0]}.device();
-    cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
+    
+    ::tvm::ffi::cuda_api::StreamHandle stream =
+        static_cast<::tvm::ffi::cuda_api::StreamHandle>(
+            TVMFFIEnvGetStream(device.device_type, device.device_id));
+
+    auto device_handle =
+        ::tvm::ffi::cuda_api::GetDeviceHandle(device.device_id);
+
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
+        ::tvm::ffi::cuda_api::SetKernelMaxDynamicSharedMem(
+            kernel,
+            shared_mem_bytes,
+            device_handle)
+    );
+    
+    // cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
 
     tvm::ffi::dim3 grid((unsigned int)grid_x, (unsigned int)grid_y, (unsigned int)grid_z);
     tvm::ffi::dim3 block({num_warps * WARP_SIZE}, 1, 1);
@@ -122,13 +221,6 @@ void {kernel_name}_launcher({cpp_params_str}) {{
 
 
 #else
-    size_t kargs_size = sizeof(KernelArgs);
-    void* config[] = {{
-        CU_LAUNCH_PARAM_BUFFER_POINTER, &kargs,
-        CU_LAUNCH_PARAM_BUFFER_SIZE,    &kargs_size,
-        CU_LAUNCH_PARAM_END
-    }};  
-
     // see https://github.com/apache/tvm-ffi/blob/d73a26783488430986fd855ae67ff7a9fb016413/include/tvm/ffi/extra/cuda/internal/unified_api.h#L115
     /*  
     TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(
@@ -139,13 +231,36 @@ void {kernel_name}_launcher({cpp_params_str}) {{
     ));
     */
 
-    CUresult result = cuLaunchKernel(kernel, 
+
+#if TVM_FFI_CUBIN_LAUNCHER_USE_DRIVER_API
+    size_t kargs_size = sizeof(KernelArgs);
+    void* config[] = {{
+        CU_LAUNCH_PARAM_BUFFER_POINTER, &kargs,
+        CU_LAUNCH_PARAM_BUFFER_SIZE,    &kargs_size,
+        CU_LAUNCH_PARAM_END
+    }};  
+
+    CUresult result = cuLaunchKernel(
+          reinterpret_cast<CUfunction>(kernel), 
           grid.x, grid.y, grid.z, 
           block.x, block.y, block.z, 
           (unsigned int)shared_mem_bytes, stream, nullptr, config);
 
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(result);
+#else
+    cudaError_t result = cudaLaunchKernel(
+        reinterpret_cast<const void*>(kernel),
+        ::dim3(grid.x, grid.y, grid.z),
+        ::dim3(block.x, block.y, block.z),
+        args,
+        (size_t)shared_mem_bytes,
+        stream);
+
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(result);
+#endif
+
     if (result != CUDA_SUCCESS) {{
-        // TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(result));
+        TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(static_cast<::tvm::ffi::cuda_api::ResultType>(result));
     }}
 
     // cudaDeviceSynchronize();

--- a/jit_kernel/triton3_5/gluon/symm_gemm.py
+++ b/jit_kernel/triton3_5/gluon/symm_gemm.py
@@ -1,0 +1,482 @@
+import ctypes
+import hashlib
+import itertools
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+
+from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
+from triton.experimental.gluon.language.nvidia.hopper import (
+    tma,
+    mbarrier,
+    fence_async_shared,
+    warpgroup_mma_init,
+    warpgroup_mma,
+    warpgroup_mma_wait,
+)
+
+from packaging import version
+
+
+def is_hopper():
+    if not torch.cuda.is_available():
+        return False
+    target = triton.runtime.driver.active.get_current_target()
+    return target.backend == "cuda" and torch.cuda.get_device_capability()[0] == 9
+
+
+# NOTE (yiakwy) : useful for multiple-die chiplet architecture :
+#   - Blackwell(2 dies), Rubin(2 dies),
+#   - Rubin Ultra(4 dies), MI300(4 dies),
+#   - MI300X(8 dies)
+#
+# Make sure SPLIT-K blocks cooperatively work on the same die to maximize the cache hit re-usage
+@gluon.jit
+def _remmap_pid(tile_id, tall_xcds, BLOCKS_PER_XCD, NUM_XCDS):
+    xcd = tile_id % NUM_XCDS
+    local_pid = tile_id // NUM_XCDS  # (local_id, xcd), strides : (NUM_XCDS, 1)
+    if xcd < tall_xcds:
+        tile_id = (
+            xcd * BLOCKS_PER_XCD + local_pid
+        )  # (xcd, local_id), strides : (BLOCKS_PER_XCD, 1)
+    else:
+        tile_id = (
+            tall_xcds * BLOCKS_PER_XCD
+            + (xcd - tall_xcds) * (BLOCKS_PER_XCD - 1)
+            + local_pid
+        )
+    return tile_id
+
+
+# NOTE (yiakwy) : see our paper for cuda kernel for swizzle of lower left triangle
+# pid = pid_m * (pid_m + 1) / 2 + pid_n
+# pid_m*2 + pid_m - 2*pid - pid_n = 0
+@gluon.jit
+def linear_to_tril(pid):
+    # row = floor((sqrt(8*pid + 1) - 1) / 2)
+    row = tl.floor((tl.math.sqrt(8.0 * pid + 1.0) - 1.0) / 2.0).to(tl.int32)
+    col = pid - (row * (row + 1)) // 2
+    return row, col
+
+
+@gluon.jit
+def _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M):
+    if GROUP_SIZE_M == 1:
+        pid_n = tile_id % num_pid_n
+        pid_m = tile_id // num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+        group_id = tile_id // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+        pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+# Ref kernels are adatped from modded-nanogpt
+if version.parse(triton.__version__) < version.parse("3.6"):
+
+    # adatped from triton 3.6+
+    @gluon.jit
+    def xcd_swizzle(pid, domain_size, XCD_SWIZZLE: gl.constexpr):
+        """
+        Swizzle the program id based on integer XCD_SWIZZLE.
+        This is useful for reording how blocks are ordered. A scheduler may, for example,
+        assign sequential blocks 0, 1, 2, 3, ..., 8, 9, 10.. to its 8 hardware units 0, 1, 2, 3, ..., 0, 1, 2.
+        This pattern may not be ideal for memory access, and it may be better to swizzle so the assignment
+        becomes 0, 0, 0, 0, ..., 1, 1, 1, ... In the swizzled arrangement, sequential blocks are assigned to
+        the same hardware unit.
+        """
+        # Number of pids per group in the new arrangement
+        pids_per_group = domain_size // XCD_SWIZZLE
+        extra_pid_groups = domain_size % XCD_SWIZZLE
+
+        # Compute current current and local pid within the group
+        group = pid % XCD_SWIZZLE
+        local_pid = pid // XCD_SWIZZLE
+
+        # Calculate new pid based on the new grouping
+        new_pid = group * pids_per_group + min(group, extra_pid_groups) + local_pid
+        return new_pid
+
+
+    @gluon.jit
+    def swizzle2d(pid, grid_m, grid_n, GROUP_M: gl.constexpr):
+        width = GROUP_M * grid_n
+
+        group_id = pid // width
+        first_pid_m = group_id * GROUP_M
+        group_size = min(grid_m - first_pid_m, GROUP_M)
+        
+        gl.assume(group_size >= 0)
+        
+        pid_m = first_pid_m + (pid % group_size)
+        pid_n = (pid % width) // (group_size)
+        return pid_m, pid_n
+    
+    # NOTE (yiakwy) : FIX newer triton API
+    setattr(gl, 'swizzle2d', swizzle2d)
+    setattr(gl, 'xcd_swizzle', xcd_swizzle)
+    
+
+# Adpated from gemm swizzle by @byronxu99 for reference
+@gluon.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = gl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+
+def XXT(A: torch.Tensor, out: torch.Tensor, use_gluon: bool = True):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    assert out.size(-2) == out.size(-1), "Output matrix has incorrect shape"
+
+    M, K = A.shape[-2:]
+    
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+    
+    gemm_op = GluonXXT(
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+    )
+    
+    return gemm_op(A, out)
+
+
+@gluon.constexpr_function
+def get_warps_per_cta(BLOCK_M, BLOCK_N, num_warps):
+    # NOTE (yiakwy) : default to warpgrup 4x1 layout
+    warps_per_cta = [4, 1]
+    m = 16
+    # Tile the atom until we have enough warps.
+    while warps_per_cta[0] * warps_per_cta[1] != num_warps:
+        # Tile along M only if it would not cause broadcasting.
+        if BLOCK_M > m * warps_per_cta[0]:
+            warps_per_cta[0] *= 2
+        else:
+            warps_per_cta[1] *= 2
+    return warps_per_cta
+
+
+@gluon.constexpr_function
+def get_instr_shape_n(BLOCK_M, BLOCK_N, num_warps):
+    m = 16
+    mReps = triton.cdiv(BLOCK_M, m)
+    nReps = triton.cdiv(num_warps, mReps)
+    maxN = max(BLOCK_N // nReps, 8)
+    n = 256
+    while n > maxN or BLOCK_N % n != 0:
+        n -= 8
+    assert n >= 8, "expected to find a valid n"
+    return n
+
+
+@gluon.constexpr_function
+def pick_wgmma_layout(dtype, BLOCK_M, BLOCK_N, num_warps):
+    m = 16
+    k = 256 // dtype.primitive_bitwidth
+    n = get_instr_shape_n(BLOCK_M, BLOCK_N, num_warps)
+    warps_per_cta = get_warps_per_cta(BLOCK_M, BLOCK_N, num_warps)
+    return gl.NVMMADistributedLayout(
+        version=[3, 0],
+        warps_per_cta=[ int(w) for w in warps_per_cta],
+        instr_shape=[int(m), int(n), int(k)],
+    )
+
+
+# TODO (yiakwy) : add support of split-k
+
+
+# NOTE（yiakwy）: the kernel is adapted from 
+#  - modded-nanogpt XXT_kernel
+#  - our new triangular sched algorithm with TMA and multcast support, see our C++ multistage gemm algorithm
+#  - gluon wgmma matmul kernel
+#    - https://github.com/triton-lang/triton/blob/main/python/tutorials/gluon/05-wgmma.py and
+#    - https://github.com/triton-lang/triton/blob/main/python/examples/gluon/03-matmul-multicta.py
+@gluon.jit
+def XXT_kernel(
+    A_desc, C_desc,
+    M, K,
+    # a_stride_b, a_stride_r, a_stride_c,
+    # c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: gl.constexpr,
+    BLOCK_SIZE_N: gl.constexpr,
+    BLOCK_SIZE_K: gl.constexpr,
+    GROUP_SIZE_M: gl.constexpr,
+    LOWER_UPPER:  gl.constexpr,
+    STAGES: gl.constexpr,
+    num_warps: gl.constexpr,
+):
+    pid = gl.program_id(axis=0)
+
+    num_pid_m = gl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = gl.cdiv(M, BLOCK_SIZE_N)
+
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid_local = pid % (num_pid_m * num_pid_n)
+    
+    if GROUP_SIZE_M == 1:
+        pid_n = pid_local % num_pid_n
+        pid_m = pid_local // num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid_local // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = gl.min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((pid_local % num_pid_in_group) % group_size_m)
+        pid_n = (pid_local % num_pid_in_group) // group_size_m
+
+    # TODO (yiakwy) : replace with
+    # pid_n, pid_m = _compute_pid(pid, num_pid_m, num_pid_n, GROUP_SIZE_M) # type: ignore
+    
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    
+    # TODO (yiakwy) : updated to new scheduler for triangular matrix
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # NOTE (yiakwy) : NV TMA does not need to use gl.DistributedLinearLayout to compute per-thread offset to load data into registers
+
+    # NOTE (yiakwy) : NV TMA does not need the combination of gl.SliceLayout and gl.BlockedLayout to to (buffer) load data into shmem
+
+    dtype: gl.constexpr = A_desc.dtype
+    tile_a = gl.allocate_shared_memory(dtype, [STAGES] + A_desc.block_type.shape, A_desc.layout)
+
+    # TODO (yiakwy) : support BLOCK_SIZE_M != BLOCK_SIZE_N
+    gl.assume(BLOCK_SIZE_M == BLOCK_SIZE_N, "only support symmetric blocking to reduce shared memory usage")
+
+    wgmma_layout: gl.constexpr = pick_wgmma_layout(dtype, BLOCK_SIZE_M, BLOCK_SIZE_N, num_warps)
+
+    acc_dtype =gl.float32
+    acc = warpgroup_mma_init(gl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype, layout=wgmma_layout))
+    
+    A_ptr = A_desc.get_ptr()
+    C_ptr = C_desc.get_ptr()
+
+    # NOTE (yiakwy) : add batched gemm support
+    if A_desc.ndim == 3:
+        A_ptr = A_ptr + batch_idx * A_desc.stride(0)
+    if C_desc.ndim == 3:
+        C_ptr = C_ptr + batch_idx * C_desc.stride(0)
+    
+    # offs_m = (m_idx + gl.arange(BLOCK_SIZE_M)) % M
+    # offs_n = (n_idx + gl.arange(BLOCK_SIZE_N)) % M
+
+    # offs_k = gl.arange(BLOCK_SIZE_K)
+        
+    off_m = m_idx * BLOCK_SIZE_M
+
+    # mma_barrier_count : gl.constexpr = 4 # COMPUTE_WARPS
+    # load_empty_bars = mbarrier.allocate_mbarrier(batch=STAGES)
+    
+    # TODO (yiakwy) : add support of WASP
+    load_ready_bars = mbarrier.allocate_mbarrier(batch=STAGES)
+
+    write_stage = 0
+    read_stage = 0
+
+    for i in gl.static_range(STAGES):
+        # mbarrier.init(load_empty_bars.index(i), count=mma_barrier_count)
+        mbarrier.init(load_ready_bars.index(i), count=1)
+
+    # 1. Ramp Up to fill
+    for i in gl.static_range(STAGES):
+        off_k = i * BLOCK_SIZE_K
+        if off_k < K:
+            a = tile_a.index(write_stage)
+
+            mbarrier.expect(load_ready_bars.index(write_stage), A_desc.block_type.nbytes)
+
+            tma.async_load(A_desc, [off_m, off_k], load_ready_bars.index(write_stage), a, multicast=True)
+
+            write_stage = (write_stage + 1) % STAGES
+        
+    tma_phase = 0
+
+    # 2. Main loop
+    for k in range(gl.cdiv(K, BLOCK_SIZE_K)):
+        k_start = k * BLOCK_SIZE_K
+        k_remaining = K - k_start
+        
+        mbarrier.wait(load_ready_bars.index(read_stage), phase=tma_phase)
+
+        # TODO (yiakwy) : add wgmma
+        a = tile_a.index(read_stage)
+        at = gl.transpose(a)
+
+        acc = warpgroup_mma_wait(num_outstanding=0, deps=(acc, ))
+        acc = warpgroup_mma(a, at, acc, is_async=True)
+
+        # issue next load
+        next_k = k + STAGES - 1
+        if next_k < K:
+            _a = tile_a.index(write_stage)
+
+            mbarrier.expect(load_ready_bars.index(write_stage), A_desc.block_type.nbytes)
+
+            tma.async_load(A_desc, [off_m, off_k], load_ready_bars.index(write_stage), _a, multicast=True)
+
+            write_stage = (write_stage + 1) % STAGES
+        
+        read_stage = (read_stage + 1) % STAGES
+        if read_stage == 0:
+            tma_phase ^= 1
+            pass
+
+    
+    # 3. Epilogue
+    acc = warpgroup_mma_wait(num_outstanding=0, deps=(acc, ))
+
+    c = gl.allocate_shared_memory(C_desc.dtype, C_desc.block_type.shape, C_desc.layout)
+    c.store(acc.to(C_desc.dtype))
+    fence_async_shared()
+
+    # NOTE (yiakwy) : store & transpose store
+    # offs_cm = m_idx + gl.arange(BLOCK_SIZE_M)
+    # offs_cn = n_idx + gl.arange(BLOCK_SIZE_N)
+    
+    # c_ptrs = C_ptr + (offs_cm[:, None] * C_desc.stride(-2) + 
+    #                     offs_cn[None, :] * C_desc.stride(-1))
+    # c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    # gl.store(c_ptrs, c, mask=c_mask)
+
+    off_n = n_idx * BLOCK_SIZE_N
+    tma.async_copy_shared_to_global(C_desc, [off_m, off_n], c)
+    
+    # c_ptrs_t = C_ptr + (offs_cn[:, None] * C_desc.stride(-2) + 
+    #                     offs_cm[None, :] * C_desc.stride(-1))
+    # c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    # gl.store(c_ptrs_t, gl.transpose(c), mask=c_mask_t)
+    tma.async_copy_shared_to_global(C_desc, [off_n, off_m], gl.transpose(c))
+    tma.store_wait(pendings=0)
+
+
+
+class GluonXXT:
+    def __init__(
+        self,
+        BLOCK_SIZE_M: int = 128,
+        BLOCK_SIZE_N: int = 128,
+        BLOCK_SIZE_K: int = 64,
+        GROUP_SIZE_M: int = 8,
+        STAGES: int = 2,
+        LOWER_UPPER: int = 1,
+    ):
+        self.BLOCK_SIZE_M = BLOCK_SIZE_M
+        self.BLOCK_SIZE_N = BLOCK_SIZE_N
+        self.BLOCK_SIZE_K = BLOCK_SIZE_K
+
+        self.a_shape = [self.BLOCK_SIZE_M, self.BLOCK_SIZE_K]
+        self.c_shape = [self.BLOCK_SIZE_M, self.BLOCK_SIZE_N]
+
+        self.GROUP_SIZE_M = GROUP_SIZE_M
+        self.LOWER_UPPER = LOWER_UPPER
+        self.STAGES = STAGES
+
+    
+    # TODO (yiakwy) : cache TVM-FFI compiled result
+    
+    def __call__(self, A: torch.Tensor, C: torch.Tensor) -> torch.Tensor:
+        a_layout = gl.NVMMASharedLayout.get_default_for(self.a_shape, gl.bfloat16)
+        c_layout = gl.NVMMASharedLayout.get_default_for(self.c_shape, gl.bfloat16)
+
+        A_desc = TensorDescriptor.from_tensor(A, self.a_shape, a_layout)
+        C_desc = TensorDescriptor.from_tensor(C, self.c_shape, c_layout)
+        
+        batch_size = A.size(0) if A.ndim == 3 else 1
+        input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+        output_batch_stride = C.stride(0) if C.ndim == 3 else 0
+
+        M, K = A.shape[-2:]
+        
+        num_pid_m = triton.cdiv(M, self.BLOCK_SIZE_M)
+        grid = (batch_size * num_pid_m * num_pid_m,)
+
+        XXT_kernel[grid](
+            A_desc, C_desc,
+            M=M,
+            K=K,
+            # a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+            # c_stride_b=output_batch_stride, c_stride_r=C.stride(-2), c_stride_c=C.stride(-1),
+            BLOCK_SIZE_M=self.BLOCK_SIZE_M, 
+            BLOCK_SIZE_N=self.BLOCK_SIZE_N, 
+            BLOCK_SIZE_K=self.BLOCK_SIZE_K, 
+            GROUP_SIZE_M=self.GROUP_SIZE_M,
+            LOWER_UPPER=self.LOWER_UPPER,
+            STAGES=self.STAGES,
+            num_warps=12 # 1 x producer, 2 x consumers
+        )
+        
+        return C
+    
+
+# Unified interface for XXT and XXL
+def compute_xxv_or_xxl(
+    A: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    mode: str = 'xxv',
+    lower_upper: int = 1,
+    use_gluon: bool = True
+) -> torch.Tensor:
+    M, K = A.shape[-2:]
+    
+    if out is None:
+        if A.ndim == 2:
+            out = torch.empty((M, M), device=A.device, dtype=A.dtype)
+        else:
+            batch_size = A.size(0)
+            out = torch.empty((batch_size, M, M), device=A.device, dtype=A.dtype)
+    
+    if mode == 'xxv':
+        return XXT(A, out, use_gluon=use_gluon)
+    elif mode == 'xxl':
+        result = XXT(A, out, use_gluon=use_gluon)
+        if lower_upper == 0:
+            mask = torch.tril(torch.ones_like(result))
+            result = result * mask
+        elif lower_upper == 1:
+            mask = torch.triu(torch.ones_like(result))
+            result = result * mask
+        return result
+    else:
+        raise ValueError(f"Unsupported mode: {mode}")

--- a/jit_kernel/triton3_5/gluon/symm_gemm.py
+++ b/jit_kernel/triton3_5/gluon/symm_gemm.py
@@ -7,22 +7,18 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 import triton
 import triton.language as tl
-from triton.tools.tensor_descriptor import TensorDescriptor
-
+from packaging import version
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
-
-from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.experimental.gluon.language.nvidia.hopper import (
-    tma,
-    mbarrier,
     fence_async_shared,
-    warpgroup_mma_init,
+    mbarrier,
+    tma,
     warpgroup_mma,
+    warpgroup_mma_init,
     warpgroup_mma_wait,
 )
-
-from packaging import version
+from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 
 
 def is_hopper():
@@ -108,7 +104,6 @@ if version.parse(triton.__version__) < version.parse("3.6"):
         new_pid = group * pids_per_group + min(group, extra_pid_groups) + local_pid
         return new_pid
 
-
     @gluon.jit
     def swizzle2d(pid, grid_m, grid_n, GROUP_M: gl.constexpr):
         width = GROUP_M * grid_n
@@ -116,16 +111,16 @@ if version.parse(triton.__version__) < version.parse("3.6"):
         group_id = pid // width
         first_pid_m = group_id * GROUP_M
         group_size = min(grid_m - first_pid_m, GROUP_M)
-        
+
         gl.assume(group_size >= 0)
-        
+
         pid_m = first_pid_m + (pid % group_size)
         pid_n = (pid % width) // (group_size)
         return pid_m, pid_n
-    
+
     # NOTE (yiakwy) : FIX newer triton API
-    setattr(gl, 'swizzle2d', swizzle2d)
-    setattr(gl, 'xcd_swizzle', xcd_swizzle)
+    setattr(gl, "swizzle2d", swizzle2d)
+    setattr(gl, "xcd_swizzle", xcd_swizzle)
 
 else:
     # for hopper tma triton 3.6+
@@ -143,22 +138,28 @@ else:
 
         gl.static_assert(batch is None or isinstance(batch.value, int))
 
-        bar = gl.allocate_shared_memory(gl.int64, [batch, num_elems], mbarrier.MBarrierLayout())
+        bar = gl.allocate_shared_memory(
+            gl.int64, [batch, num_elems], mbarrier.MBarrierLayout()
+        )
         return bar
 
     # NOTE (yiakwy) : hopper does not implement allocate_mbarrier method
-    if not hasattr(mbarrier, 'allocate_mbarrier'):
-        setattr(mbarrier, 'allocate_mbarrier', allocate_mbarrier)
+    if not hasattr(mbarrier, "allocate_mbarrier"):
+        setattr(mbarrier, "allocate_mbarrier", allocate_mbarrier)
 
     # NOTE (yiakwy) : see https://github.com/triton-lang/triton/pull/10083
     @gl._core.builtin
-    def async_load(tensor_desc, coord, barrier, result, pred=True, multicast=False, _semantic=None):
+    def async_load(
+        tensor_desc, coord, barrier, result, pred=True, multicast=False, _semantic=None
+    ):
         # NOTE (yiakwy) : TMA multicast is not supported in triton 3.6 release
-        return tma.async_copy_global_to_shared(tensor_desc, coord, barrier, result, pred=pred, _semantic=_semantic)
+        return tma.async_copy_global_to_shared(
+            tensor_desc, coord, barrier, result, pred=pred, _semantic=_semantic
+        )
 
-    if not hasattr(tma, 'acync_load'):
-        setattr(tma, 'async_load', async_load)
-    
+    if not hasattr(tma, "async_load"):
+        setattr(tma, "async_load", async_load)
+
 
 # Adpated from gemm swizzle by @byronxu99 for reference
 @gluon.jit
@@ -180,7 +181,7 @@ def _pid_to_block(
     # Map PID to 2D grid of blocks
     pid_m = pid // num_pid_n
     pid_n = pid % num_pid_n
-    pid_m, pid_n = gl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+    pid_m, pid_n = gl.swizzle2d(pid, num_pid_m, num_pid_n, GROUP_SIZE_M)
 
     m_idx = pid_m * BLOCK_SIZE_M
     n_idx = pid_n * BLOCK_SIZE_N
@@ -195,12 +196,12 @@ def XXT(A: torch.Tensor, out: torch.Tensor, use_gluon: bool = True):
     assert out.size(-2) == out.size(-1), "Output matrix has incorrect shape"
 
     M, K = A.shape[-2:]
-    
+
     if K == 768:
         BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
     else:
-        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
-    
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 128
+
     gemm_op = GluonXXT(
         BLOCK_SIZE_M=BLOCK_SIZE_M,
         BLOCK_SIZE_N=BLOCK_SIZE_N,
@@ -208,7 +209,7 @@ def XXT(A: torch.Tensor, out: torch.Tensor, use_gluon: bool = True):
         GROUP_SIZE_M=8,
         LOWER_UPPER=1,
     )
-    
+
     return gemm_op(A, out)
 
 
@@ -248,7 +249,7 @@ def pick_wgmma_layout(dtype, BLOCK_M, BLOCK_N, num_warps):
     warps_per_cta = get_warps_per_cta(BLOCK_M, BLOCK_N, num_warps)
     return gl.NVMMADistributedLayout(
         version=[3, 0],
-        warps_per_cta=[ int(w) for w in warps_per_cta],
+        warps_per_cta=[int(w) for w in warps_per_cta],
         instr_shape=[int(m), int(n), int(k)],
     )
 
@@ -256,7 +257,7 @@ def pick_wgmma_layout(dtype, BLOCK_M, BLOCK_N, num_warps):
 # TODO (yiakwy) : add support of split-k
 
 
-# NOTE（yiakwy）: the kernel is adapted from 
+# NOTE（yiakwy）: the kernel is adapted from
 #  - modded-nanogpt XXT_kernel
 #  - our new triangular sched algorithm with TMA and multcast support, see our C++ multistage gemm algorithm
 #  - gluon wgmma matmul kernel
@@ -264,15 +265,17 @@ def pick_wgmma_layout(dtype, BLOCK_M, BLOCK_N, num_warps):
 #    - https://github.com/triton-lang/triton/blob/main/python/examples/gluon/03-matmul-multicta.py
 @gluon.jit
 def XXT_kernel(
-    A_desc, C_desc,
-    M, K,
+    A_desc,
+    C_desc,
+    M,
+    K,
     # a_stride_b, a_stride_r, a_stride_c,
     # c_stride_b, c_stride_r, c_stride_c,
     BLOCK_SIZE_M: gl.constexpr,
     BLOCK_SIZE_N: gl.constexpr,
     BLOCK_SIZE_K: gl.constexpr,
     GROUP_SIZE_M: gl.constexpr,
-    LOWER_UPPER:  gl.constexpr,
+    LOWER_UPPER: gl.constexpr,
     STAGES: gl.constexpr,
     num_warps: gl.constexpr,
 ):
@@ -283,7 +286,7 @@ def XXT_kernel(
 
     batch_idx = pid // (num_pid_m * num_pid_n)
     pid_local = pid % (num_pid_m * num_pid_n)
-    
+
     if GROUP_SIZE_M == 1:
         pid_n = pid_local % num_pid_n
         pid_m = pid_local // num_pid_n
@@ -297,10 +300,10 @@ def XXT_kernel(
 
     # TODO (yiakwy) : replace with
     # pid_n, pid_m = _compute_pid(pid, num_pid_m, num_pid_n, GROUP_SIZE_M) # type: ignore
-    
+
     m_idx = pid_m * BLOCK_SIZE_M
     n_idx = pid_n * BLOCK_SIZE_N
-    
+
     # TODO (yiakwy) : updated to new scheduler for triangular matrix
     skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
     skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
@@ -318,21 +321,29 @@ def XXT_kernel(
     # NOTE (yiakwy) : NV TMA does not need the combination of gl.SliceLayout and gl.BlockedLayout to to (buffer) load data into shmem
 
     dtype: gl.constexpr = A_desc.dtype
-    tile_a = gl.allocate_shared_memory(dtype, [STAGES] + A_desc.block_type.shape, A_desc.layout)
+    tile_a = gl.allocate_shared_memory(
+        dtype, [STAGES] + A_desc.block_type.shape, A_desc.layout
+    )
 
     # TODO (yiakwy) : support BLOCK_SIZE_M != BLOCK_SIZE_N
-    gl.assume(BLOCK_SIZE_M == BLOCK_SIZE_N) #  "only support symmetric blocking to reduce shared memory usage"
+    gl.assume(
+        BLOCK_SIZE_M == BLOCK_SIZE_N
+    )  #  "only support symmetric blocking to reduce shared memory usage"
 
-    wgmma_layout: gl.constexpr = pick_wgmma_layout(dtype, BLOCK_SIZE_M, BLOCK_SIZE_N, num_warps)
+    wgmma_layout: gl.constexpr = pick_wgmma_layout(
+        dtype, BLOCK_SIZE_M, BLOCK_SIZE_N, num_warps
+    )
 
-    acc_dtype =gl.float32
-    acc = warpgroup_mma_init(gl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype, layout=wgmma_layout))
-           
+    acc_dtype = gl.float32
+    acc = warpgroup_mma_init(
+        gl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype, layout=wgmma_layout)
+    )
+
     off_m = m_idx
 
     # mma_barrier_count : gl.constexpr = 4 # COMPUTE_WARPS
     # load_empty_bars = allocate_mbarrier(batch=STAGES)
-    
+
     # TODO (yiakwy) : add support of WASP
     load_ready_bars = mbarrier.allocate_mbarrier(batch=STAGES)
 
@@ -349,47 +360,63 @@ def XXT_kernel(
         if off_k < K:
             a = tile_a.index(write_stage)
 
-            mbarrier.expect(load_ready_bars.index(write_stage), A_desc.block_type.nbytes)
+            mbarrier.expect(
+                load_ready_bars.index(write_stage), A_desc.block_type.nbytes
+            )
 
             # NOTE (yiakwy) : triton 3.6 does not suppor multicast, please updated to triton 3.7 (after Apri 2026) for the performance boost
-            tma.async_load(A_desc, [off_m, off_k], load_ready_bars.index(write_stage), a, multicast=True)
+            tma.async_load(
+                A_desc,
+                [off_m, off_k],
+                load_ready_bars.index(write_stage),
+                a,
+                multicast=True,
+            )
             # async_copy_global_to_shared(tensor_desc, coord, barrier, result, pred=True, _semantic=None):
 
             write_stage = (write_stage + 1) % STAGES
-        
+
     tma_phase = 0
 
     # 2. Main loop
     ssteps = gl.cdiv(K, BLOCK_SIZE_K)
     for k in range(gl.cdiv(K, BLOCK_SIZE_K)):
         off_k = k * BLOCK_SIZE_K
-        
+
         mbarrier.wait(load_ready_bars.index(read_stage), phase=tma_phase)
 
         # TODO (yiakwy) : add wgmma
         a = tile_a.index(read_stage)
-        at = a.permute((1, 0)) # gl.transpose(a)
+        at = a.permute((1, 0))  # gl.transpose(a)
 
-        acc = warpgroup_mma_wait(num_outstanding=0, deps=(acc, ))
+        acc = warpgroup_mma_wait(num_outstanding=0, deps=(acc,))
         acc = warpgroup_mma(a, at, acc, is_async=True)
 
         # issue next load
-        next_k = (k + STAGES) * BLOCK_SIZE_K 
+        next_k = (k + STAGES) * BLOCK_SIZE_K
         if next_k < K:
             _a = tile_a.index(write_stage)
 
-            mbarrier.expect(load_ready_bars.index(write_stage), A_desc.block_type.nbytes)
+            mbarrier.expect(
+                load_ready_bars.index(write_stage), A_desc.block_type.nbytes
+            )
 
-            tma.async_load(A_desc, [off_m, next_k], load_ready_bars.index(write_stage), _a, multicast=True)
+            tma.async_load(
+                A_desc,
+                [off_m, next_k],
+                load_ready_bars.index(write_stage),
+                _a,
+                multicast=True,
+            )
 
             write_stage = (write_stage + 1) % STAGES
-        
+
         read_stage = (read_stage + 1) % STAGES
         if read_stage == 0:
             tma_phase ^= 1
-    
+
     # 3. Epilogue
-    acc = warpgroup_mma_wait(num_outstanding=0, deps=(acc, ))
+    acc = warpgroup_mma_wait(num_outstanding=0, deps=(acc,))
 
     c = gl.allocate_shared_memory(C_desc.dtype, C_desc.block_type.shape, C_desc.layout)
     c.store(acc.to(C_desc.dtype))
@@ -399,7 +426,7 @@ def XXT_kernel(
     off_n = n_idx
     tma.async_copy_shared_to_global(C_desc, [off_m, off_n], c)
 
-    ct = c.permute((1,0)) # gl.transpose(c)
+    ct = c.permute((1, 0))  # gl.transpose(c)
     tma.async_copy_shared_to_global(C_desc, [off_n, off_m], ct)
     tma.store_wait(pendings=0)
 
@@ -411,8 +438,9 @@ class GluonXXT:
         BLOCK_SIZE_N: int = 128,
         BLOCK_SIZE_K: int = 64,
         GROUP_SIZE_M: int = 8,
-        STAGES: int = 2,
-        LOWER_UPPER: int = 1, # NOTE (yiakwy) : 1 skip block above diaglogue; 0 skip block below diaglogue
+        STAGES: int = 4,
+        NUM_WARPS: int = 8,
+        LOWER_UPPER: int = 1,  # NOTE (yiakwy) : 1 skip block above diaglogue; 0 skip block below diaglogue
     ):
         self.BLOCK_SIZE_M = BLOCK_SIZE_M
         self.BLOCK_SIZE_N = BLOCK_SIZE_N
@@ -422,66 +450,69 @@ class GluonXXT:
         self.c_shape = [self.BLOCK_SIZE_M, self.BLOCK_SIZE_N]
 
         self.GROUP_SIZE_M = GROUP_SIZE_M
-        self.LOWER_UPPER = LOWER_UPPER
         self.STAGES = STAGES
+        self.NUM_WARPS = NUM_WARPS
+        self.LOWER_UPPER = LOWER_UPPER
 
-    
     # TODO (yiakwy) : cache TVM-FFI compiled result
-    
-    def __call__(self, A: torch.Tensor, C: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+    def __call__(
+        self, A: torch.Tensor, C: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         M, K = A.shape[-2:]
 
         if C is None:
             if A.ndim == 2:
                 C = torch.empty((M, M), device=A.device, dtype=A.dtype)
             else:
-                C = torch.empty( A.shape[:-2] + (M, M), device=A.device, dtype=A.dtype)
+                C = torch.empty(A.shape[:-2] + (M, M), device=A.device, dtype=A.dtype)
 
         a_layout = gl.NVMMASharedLayout.get_default_for(self.a_shape, gl.bfloat16)
         c_layout = gl.NVMMASharedLayout.get_default_for(self.c_shape, gl.bfloat16)
 
         A_desc = TensorDescriptor.from_tensor(A, self.a_shape, a_layout)
         C_desc = TensorDescriptor.from_tensor(C, self.c_shape, c_layout)
-        
+
         batch_size = A.size(0) if A.ndim == 3 else 1
         # input_batch_stride = A.stride(0) if A.ndim == 3 else 0
         # output_batch_stride = C.stride(0) if C.ndim == 3 else 0
 
         M, K = A.shape[-2:]
-        
+
         num_pid_m = triton.cdiv(M, self.BLOCK_SIZE_M)
         grid = (batch_size * num_pid_m * num_pid_m,)
 
         XXT_kernel[grid](
-            A_desc, C_desc,
+            A_desc,
+            C_desc,
             M=M,
             K=K,
             # a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
             # c_stride_b=output_batch_stride, c_stride_r=C.stride(-2), c_stride_c=C.stride(-1),
-            BLOCK_SIZE_M=self.BLOCK_SIZE_M, 
-            BLOCK_SIZE_N=self.BLOCK_SIZE_N, 
-            BLOCK_SIZE_K=self.BLOCK_SIZE_K, 
+            BLOCK_SIZE_M=self.BLOCK_SIZE_M,
+            BLOCK_SIZE_N=self.BLOCK_SIZE_N,
+            BLOCK_SIZE_K=self.BLOCK_SIZE_K,
             GROUP_SIZE_M=self.GROUP_SIZE_M,
             LOWER_UPPER=self.LOWER_UPPER,
             STAGES=self.STAGES,
-            num_warps=8 # 8 for multi stages, 12 for 1 x producer wg, 2 x consumers wg
+            num_warps=self.NUM_WARPS,  # 8 for multi stages, 12 for 1 x producer wg, 2 x consumers wg
         )
-        
+
         return C
-    
+
 
 # Unified interface for XXT and XXL
 def symm_gemm(
-    A: torch.Tensor,
-    out: Optional[torch.Tensor] = None,
-    use_gluon: bool = True
+    A: torch.Tensor, out: Optional[torch.Tensor] = None, use_gluon: bool = True
 ) -> torch.Tensor:
     M, K = A.shape[-2:]
-    
+
     if out is None:
         if A.ndim == 2:
             out = torch.empty((M, M), device=A.device, dtype=A.dtype)
         else:
-            out = torch.empty( A.shape[:-2] + (M, M), device=A.device, dtype=A.dtype)
-    
-    raise NotImplementedError("symm_gemm is not implemented yet, please use XXT instead")
+            out = torch.empty(A.shape[:-2] + (M, M), device=A.device, dtype=A.dtype)
+
+    raise NotImplementedError(
+        "symm_gemm is not implemented yet, please use XXT instead"
+    )

--- a/jit_kernel/triton3_5/gluon/symm_gemm.py
+++ b/jit_kernel/triton3_5/gluon/symm_gemm.py
@@ -126,6 +126,38 @@ if version.parse(triton.__version__) < version.parse("3.6"):
     # NOTE (yiakwy) : FIX newer triton API
     setattr(gl, 'swizzle2d', swizzle2d)
     setattr(gl, 'xcd_swizzle', xcd_swizzle)
+
+else:
+    # for hopper tma triton 3.6+
+
+    @gluon.jit
+    def allocate_mbarrier(batch: gl.constexpr = None, two_ctas: gl.constexpr = False):
+        """
+        Helper function to allocate an mbarrier
+
+        Args:
+            two_ctas (bool): Whether the barrier should synchronize every other CTA
+        """
+        num_ctas: gl.constexpr = gl.num_ctas()
+        num_elems: gl.constexpr = num_ctas if not two_ctas else num_ctas // 2
+
+        gl.static_assert(batch is None or isinstance(batch.value, int))
+
+        bar = gl.allocate_shared_memory(gl.int64, [batch, num_elems], mbarrier.MBarrierLayout())
+        return bar
+
+    # NOTE (yiakwy) : hopper does not implement allocate_mbarrier method
+    if not hasattr(mbarrier, 'allocate_mbarrier'):
+        setattr(mbarrier, 'allocate_mbarrier', allocate_mbarrier)
+
+    # NOTE (yiakwy) : see https://github.com/triton-lang/triton/pull/10083
+    @gl._core.builtin
+    def async_load(tensor_desc, coord, barrier, result, pred=True, multicast=False, _semantic=None):
+        # NOTE (yiakwy) : TMA multicast is not supported in triton 3.6 release
+        return tma.async_copy_global_to_shared(tensor_desc, coord, barrier, result, pred=pred, _semantic=_semantic)
+
+    if not hasattr(tma, 'acync_load'):
+        setattr(tma, 'async_load', async_load)
     
 
 # Adpated from gemm swizzle by @byronxu99 for reference
@@ -259,7 +291,7 @@ def XXT_kernel(
         num_pid_in_group = GROUP_SIZE_M * num_pid_n
         group_id = pid_local // num_pid_in_group
         first_pid_m = group_id * GROUP_SIZE_M
-        group_size_m = gl.min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
         pid_m = first_pid_m + ((pid_local % num_pid_in_group) % group_size_m)
         pid_n = (pid_local % num_pid_in_group) // group_size_m
 
@@ -272,8 +304,14 @@ def XXT_kernel(
     # TODO (yiakwy) : updated to new scheduler for triangular matrix
     skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
     skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+
+    gl.assume(skip_block_above_diag == True)
+
     if skip_block_below_diag or skip_block_above_diag:
         return
+
+    m_idx = m_idx + batch_idx * M
+    n_idx = n_idx + batch_idx * M
 
     # NOTE (yiakwy) : NV TMA does not need to use gl.DistributedLinearLayout to compute per-thread offset to load data into registers
 
@@ -283,31 +321,17 @@ def XXT_kernel(
     tile_a = gl.allocate_shared_memory(dtype, [STAGES] + A_desc.block_type.shape, A_desc.layout)
 
     # TODO (yiakwy) : support BLOCK_SIZE_M != BLOCK_SIZE_N
-    gl.assume(BLOCK_SIZE_M == BLOCK_SIZE_N, "only support symmetric blocking to reduce shared memory usage")
+    gl.assume(BLOCK_SIZE_M == BLOCK_SIZE_N) #  "only support symmetric blocking to reduce shared memory usage"
 
     wgmma_layout: gl.constexpr = pick_wgmma_layout(dtype, BLOCK_SIZE_M, BLOCK_SIZE_N, num_warps)
 
     acc_dtype =gl.float32
     acc = warpgroup_mma_init(gl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype, layout=wgmma_layout))
-    
-    A_ptr = A_desc.get_ptr()
-    C_ptr = C_desc.get_ptr()
-
-    # NOTE (yiakwy) : add batched gemm support
-    if A_desc.ndim == 3:
-        A_ptr = A_ptr + batch_idx * A_desc.stride(0)
-    if C_desc.ndim == 3:
-        C_ptr = C_ptr + batch_idx * C_desc.stride(0)
-    
-    # offs_m = (m_idx + gl.arange(BLOCK_SIZE_M)) % M
-    # offs_n = (n_idx + gl.arange(BLOCK_SIZE_N)) % M
-
-    # offs_k = gl.arange(BLOCK_SIZE_K)
-        
-    off_m = m_idx * BLOCK_SIZE_M
+           
+    off_m = m_idx
 
     # mma_barrier_count : gl.constexpr = 4 # COMPUTE_WARPS
-    # load_empty_bars = mbarrier.allocate_mbarrier(batch=STAGES)
+    # load_empty_bars = allocate_mbarrier(batch=STAGES)
     
     # TODO (yiakwy) : add support of WASP
     load_ready_bars = mbarrier.allocate_mbarrier(batch=STAGES)
@@ -327,42 +351,42 @@ def XXT_kernel(
 
             mbarrier.expect(load_ready_bars.index(write_stage), A_desc.block_type.nbytes)
 
+            # NOTE (yiakwy) : triton 3.6 does not suppor multicast, please updated to triton 3.7 (after Apri 2026) for the performance boost
             tma.async_load(A_desc, [off_m, off_k], load_ready_bars.index(write_stage), a, multicast=True)
+            # async_copy_global_to_shared(tensor_desc, coord, barrier, result, pred=True, _semantic=None):
 
             write_stage = (write_stage + 1) % STAGES
         
     tma_phase = 0
 
     # 2. Main loop
+    ssteps = gl.cdiv(K, BLOCK_SIZE_K)
     for k in range(gl.cdiv(K, BLOCK_SIZE_K)):
-        k_start = k * BLOCK_SIZE_K
-        k_remaining = K - k_start
+        off_k = k * BLOCK_SIZE_K
         
         mbarrier.wait(load_ready_bars.index(read_stage), phase=tma_phase)
 
         # TODO (yiakwy) : add wgmma
         a = tile_a.index(read_stage)
-        at = gl.transpose(a)
+        at = a.permute((1, 0)) # gl.transpose(a)
 
         acc = warpgroup_mma_wait(num_outstanding=0, deps=(acc, ))
         acc = warpgroup_mma(a, at, acc, is_async=True)
 
         # issue next load
-        next_k = k + STAGES - 1
+        next_k = (k + STAGES) * BLOCK_SIZE_K 
         if next_k < K:
             _a = tile_a.index(write_stage)
 
             mbarrier.expect(load_ready_bars.index(write_stage), A_desc.block_type.nbytes)
 
-            tma.async_load(A_desc, [off_m, off_k], load_ready_bars.index(write_stage), _a, multicast=True)
+            tma.async_load(A_desc, [off_m, next_k], load_ready_bars.index(write_stage), _a, multicast=True)
 
             write_stage = (write_stage + 1) % STAGES
         
         read_stage = (read_stage + 1) % STAGES
         if read_stage == 0:
             tma_phase ^= 1
-            pass
-
     
     # 3. Epilogue
     acc = warpgroup_mma_wait(num_outstanding=0, deps=(acc, ))
@@ -372,24 +396,12 @@ def XXT_kernel(
     fence_async_shared()
 
     # NOTE (yiakwy) : store & transpose store
-    # offs_cm = m_idx + gl.arange(BLOCK_SIZE_M)
-    # offs_cn = n_idx + gl.arange(BLOCK_SIZE_N)
-    
-    # c_ptrs = C_ptr + (offs_cm[:, None] * C_desc.stride(-2) + 
-    #                     offs_cn[None, :] * C_desc.stride(-1))
-    # c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
-    # gl.store(c_ptrs, c, mask=c_mask)
-
-    off_n = n_idx * BLOCK_SIZE_N
+    off_n = n_idx
     tma.async_copy_shared_to_global(C_desc, [off_m, off_n], c)
-    
-    # c_ptrs_t = C_ptr + (offs_cn[:, None] * C_desc.stride(-2) + 
-    #                     offs_cm[None, :] * C_desc.stride(-1))
-    # c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
-    # gl.store(c_ptrs_t, gl.transpose(c), mask=c_mask_t)
-    tma.async_copy_shared_to_global(C_desc, [off_n, off_m], gl.transpose(c))
-    tma.store_wait(pendings=0)
 
+    ct = c.permute((1,0)) # gl.transpose(c)
+    tma.async_copy_shared_to_global(C_desc, [off_n, off_m], ct)
+    tma.store_wait(pendings=0)
 
 
 class GluonXXT:
@@ -400,7 +412,7 @@ class GluonXXT:
         BLOCK_SIZE_K: int = 64,
         GROUP_SIZE_M: int = 8,
         STAGES: int = 2,
-        LOWER_UPPER: int = 1,
+        LOWER_UPPER: int = 1, # NOTE (yiakwy) : 1 skip block above diaglogue; 0 skip block below diaglogue
     ):
         self.BLOCK_SIZE_M = BLOCK_SIZE_M
         self.BLOCK_SIZE_N = BLOCK_SIZE_N
@@ -416,7 +428,15 @@ class GluonXXT:
     
     # TODO (yiakwy) : cache TVM-FFI compiled result
     
-    def __call__(self, A: torch.Tensor, C: torch.Tensor) -> torch.Tensor:
+    def __call__(self, A: torch.Tensor, C: Optional[torch.Tensor] = None) -> torch.Tensor:
+        M, K = A.shape[-2:]
+
+        if C is None:
+            if A.ndim == 2:
+                C = torch.empty((M, M), device=A.device, dtype=A.dtype)
+            else:
+                C = torch.empty( A.shape[:-2] + (M, M), device=A.device, dtype=A.dtype)
+
         a_layout = gl.NVMMASharedLayout.get_default_for(self.a_shape, gl.bfloat16)
         c_layout = gl.NVMMASharedLayout.get_default_for(self.c_shape, gl.bfloat16)
 
@@ -424,8 +444,8 @@ class GluonXXT:
         C_desc = TensorDescriptor.from_tensor(C, self.c_shape, c_layout)
         
         batch_size = A.size(0) if A.ndim == 3 else 1
-        input_batch_stride = A.stride(0) if A.ndim == 3 else 0
-        output_batch_stride = C.stride(0) if C.ndim == 3 else 0
+        # input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+        # output_batch_stride = C.stride(0) if C.ndim == 3 else 0
 
         M, K = A.shape[-2:]
         
@@ -444,18 +464,16 @@ class GluonXXT:
             GROUP_SIZE_M=self.GROUP_SIZE_M,
             LOWER_UPPER=self.LOWER_UPPER,
             STAGES=self.STAGES,
-            num_warps=12 # 1 x producer, 2 x consumers
+            num_warps=8 # 8 for multi stages, 12 for 1 x producer wg, 2 x consumers wg
         )
         
         return C
     
 
 # Unified interface for XXT and XXL
-def compute_xxv_or_xxl(
+def symm_gemm(
     A: torch.Tensor,
     out: Optional[torch.Tensor] = None,
-    mode: str = 'xxv',
-    lower_upper: int = 1,
     use_gluon: bool = True
 ) -> torch.Tensor:
     M, K = A.shape[-2:]
@@ -464,19 +482,6 @@ def compute_xxv_or_xxl(
         if A.ndim == 2:
             out = torch.empty((M, M), device=A.device, dtype=A.dtype)
         else:
-            batch_size = A.size(0)
-            out = torch.empty((batch_size, M, M), device=A.device, dtype=A.dtype)
+            out = torch.empty( A.shape[:-2] + (M, M), device=A.device, dtype=A.dtype)
     
-    if mode == 'xxv':
-        return XXT(A, out, use_gluon=use_gluon)
-    elif mode == 'xxl':
-        result = XXT(A, out, use_gluon=use_gluon)
-        if lower_upper == 0:
-            mask = torch.tril(torch.ones_like(result))
-            result = result * mask
-        elif lower_upper == 1:
-            mask = torch.triu(torch.ones_like(result))
-            result = result * mask
-        return result
-    else:
-        raise ValueError(f"Unsupported mode: {mode}")
+    raise NotImplementedError("symm_gemm is not implemented yet, please use XXT instead")

--- a/jit_kernel/triton3_5/symm_gemm.py
+++ b/jit_kernel/triton3_5/symm_gemm.py
@@ -7,9 +7,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 import triton
 import triton.language as tl
-from triton.tools.tensor_descriptor import TensorDescriptor
-
 from packaging import version
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 
 # NOTE (yiakwy) : useful for multiple-die chiplet architecture :
@@ -90,7 +89,6 @@ if version.parse(triton.__version__) < version.parse("3.6"):
         new_pid = group * pids_per_group + min(group, extra_pid_groups) + local_pid
         return new_pid
 
-
     @triton.jit
     def swizzle2d(pid, grid_m, grid_n, GROUP_M: tl.constexpr):
         width = GROUP_M * grid_n
@@ -102,11 +100,11 @@ if version.parse(triton.__version__) < version.parse("3.6"):
         pid_m = first_pid_m + (pid % group_size)
         pid_n = (pid % width) // (group_size)
         return pid_m, pid_n
-    
+
     # NOTE (yiakwy) : FIX newer triton API
-    setattr(tl, 'swizzle2d', swizzle2d)
-    setattr(tl, 'xcd_swizzle', xcd_swizzle)
-    
+    setattr(tl, "swizzle2d", swizzle2d)
+    setattr(tl, "xcd_swizzle", xcd_swizzle)
+
 
 # Adpated from gemm swizzle by @byronxu99 for reference
 @triton.jit
@@ -139,10 +137,16 @@ def _pid_to_block(
 # adapted from modded_nanogpt as ref
 @triton.jit
 def XXT_kernel(
-    A_ptr, C_ptr,
-    M, K,
-    a_stride_b, a_stride_r, a_stride_c,
-    c_stride_b, c_stride_r, c_stride_c,
+    A_ptr,
+    C_ptr,
+    M,
+    K,
+    a_stride_b,
+    a_stride_r,
+    a_stride_c,
+    c_stride_b,
+    c_stride_r,
+    c_stride_c,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
@@ -168,7 +172,7 @@ def XXT_kernel(
     offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
     offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    
+
     # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
     # Load A[m, k] -> shape (BM, BK)
     a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
@@ -215,7 +219,9 @@ def XXT(A: torch.Tensor, out: Optional[torch.Tensor] = None):
 
     if out is None:
         if A.ndim == 3:
-            out = torch.zeros( A.shape[:-2] + (M, M), device=A.device, dtype=torch.float16)
+            out = torch.zeros(
+                A.shape[:-2] + (M, M), device=A.device, dtype=torch.float16
+            )
         else:
             out = torch.zeros((M, M), device=A.device, dtype=torch.float16)
 
@@ -261,10 +267,16 @@ def XXT(A: torch.Tensor, out: Optional[torch.Tensor] = None):
 # adapted from modded_nanogpt as ref
 @triton.jit
 def XTX_kernel(
-    A_ptr, C_ptr,
-    M, K,
-    a_stride_b, a_stride_r, a_stride_c,
-    c_stride_b, c_stride_r, c_stride_c,
+    A_ptr,
+    C_ptr,
+    M,
+    K,
+    a_stride_b,
+    a_stride_r,
+    a_stride_c,
+    c_stride_b,
+    c_stride_r,
+    c_stride_c,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
@@ -274,7 +286,7 @@ def XTX_kernel(
     """
     Compute C = A.T @ A where A is (M, K) and C is (K, K).
     This is the transpose variant of XXT for tall matrices.
-    
+
     The output matrix C is symmetric, so we compute upper triangle and mirror.
     We iterate over blocks of M (the reduction dimension after transpose).
     """
@@ -298,8 +310,12 @@ def XTX_kernel(
     # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
     # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
     # - We reduce over M (the shared dimension)
-    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
-    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_k = (
+        k_idx + tl.arange(0, BLOCK_SIZE_M)
+    ) % K  # Output row indices (columns of A)
+    offs_n = (
+        n_idx + tl.arange(0, BLOCK_SIZE_N)
+    ) % K  # Output col indices (columns of A)
     offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
 
     # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
@@ -344,14 +360,14 @@ def XTX_kernel(
 def XTX(A: torch.Tensor, out: Optional[torch.Tensor] = None):
     """
     Launch Triton kernel to compute C = A.T @ A
-    
+
     For tall matrices (M > K), this is more efficient than transposing
     and using XXT because the intermediate products are smaller (K x K vs M x M).
-    
+
     Args:
         A: Input tensor of shape (M, K) or (batch, M, K)
         out: Output tensor of shape (K, K) or (batch, K, K)
-    
+
     Returns:
         out: The same output tensor, filled with A.T @ A
     """
@@ -360,12 +376,18 @@ def XTX(A: torch.Tensor, out: Optional[torch.Tensor] = None):
 
     if out is None:
         if A.ndim == 3:
-            out = torch.zeros( A.shape[:-2] + (M, M), device=A.device, dtype=torch.float16)
+            out = torch.zeros(
+                A.shape[:-2] + (K, K), device=A.device, dtype=torch.float16
+            )
         else:
-            out = torch.zeros((M, M), device=A.device, dtype=torch.float16)
+            out = torch.zeros((K, K), device=A.device, dtype=torch.float16)
 
-    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
-    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert (
+        out.size(-2) == K
+    ), f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert (
+        out.size(-1) == K
+    ), f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
 
     batch_size = A.size(0) if A.ndim == 3 else 1
     input_batch_stride = A.stride(0) if A.ndim == 3 else 0

--- a/jit_kernel/triton3_5/symm_gemm.py
+++ b/jit_kernel/triton3_5/symm_gemm.py
@@ -135,6 +135,8 @@ def _pid_to_block(
     return batch_idx, m_idx, n_idx
 
 
+# TODO (yiakwy) : remove
+# adapted from modded_nanogpt as ref
 @triton.jit
 def XXT_kernel(
     A_ptr, C_ptr,
@@ -202,12 +204,21 @@ def XXT_kernel(
     tl.store(c_ptrs_t, output.T, mask=c_mask_t)
 
 
-def XXT(A: torch.Tensor, out: torch.Tensor):
+# TODO (yiakwy) : remove
+# adapted from modded_nanogpt as ref
+def XXT(A: torch.Tensor, out: Optional[torch.Tensor] = None):
     """
     Launch Triton kernel to compute C = A @ A.T
     """
     assert A.ndim == 2 or A.ndim == 3
     M, K = A.shape[-2:]
+
+    if out is None:
+        if A.ndim == 3:
+            out = torch.zeros( A.shape[:-2] + (M, M), device=A.device, dtype=torch.float16)
+        else:
+            out = torch.zeros((M, M), device=A.device, dtype=torch.float16)
+
     assert out.size(-2) == M, "Output matrix has incorrect shape"
     assert out.size(-1) == M, "Output matrix has incorrect shape"
 
@@ -225,6 +236,151 @@ def XXT(A: torch.Tensor, out: torch.Tensor):
 
     grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
     XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+# TODO (yiakwy) : remove
+# adapted from modded_nanogpt as ref
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+# TODO (yiakwy) : remove
+# adapted from modded_nanogpt as ref
+def XTX(A: torch.Tensor, out: Optional[torch.Tensor] = None):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+
+    if out is None:
+        if A.ndim == 3:
+            out = torch.zeros( A.shape[:-2] + (M, M), device=A.device, dtype=torch.float16)
+        else:
+            out = torch.zeros((M, M), device=A.device, dtype=torch.float16)
+
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
         A_ptr=A,
         C_ptr=out,
         M=M,

--- a/jit_kernel/triton3_5/symm_gemm.py
+++ b/jit_kernel/triton3_5/symm_gemm.py
@@ -1,0 +1,246 @@
+import ctypes
+import hashlib
+import itertools
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from packaging import version
+
+
+# NOTE (yiakwy) : useful for multiple-die chiplet architecture :
+#   - Blackwell(2 dies), Rubin(2 dies),
+#   - Rubin Ultra(4 dies), MI300(4 dies),
+#   - MI300X(8 dies)
+#
+# Make sure SPLIT-K blocks cooperatively work on the same die to maximize the cache hit re-usage
+@triton.jit
+def _remmap_pid(tile_id, tall_xcds, BLOCKS_PER_XCD, NUM_XCDS):
+    xcd = tile_id % NUM_XCDS
+    local_pid = tile_id // NUM_XCDS  # (local_id, xcd), strides : (NUM_XCDS, 1)
+    if xcd < tall_xcds:
+        tile_id = (
+            xcd * BLOCKS_PER_XCD + local_pid
+        )  # (xcd, local_id), strides : (BLOCKS_PER_XCD, 1)
+    else:
+        tile_id = (
+            tall_xcds * BLOCKS_PER_XCD
+            + (xcd - tall_xcds) * (BLOCKS_PER_XCD - 1)
+            + local_pid
+        )
+    return tile_id
+
+
+# NOTE (yiakwy) : see our paper for cuda kernel for swizzle of lower left triangle
+# pid = pid_m * (pid_m + 1) / 2 + pid_n
+# pid_m*2 + pid_m - 2*pid - pid_n = 0
+@triton.jit
+def linear_to_tril(pid):
+    # row = floor((sqrt(8*pid + 1) - 1) / 2)
+    row = tl.floor((tl.math.sqrt(8.0 * pid + 1.0) - 1.0) / 2.0).to(tl.int32)
+    col = pid - (row * (row + 1)) // 2
+    return row, col
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M):
+    if GROUP_SIZE_M == 1:
+        pid_n = tile_id % num_pid_n
+        pid_m = tile_id // num_pid_n
+
+        num_pid_in_group = num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+        group_id = tile_id // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+        pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+# Ref kernels are adpated from modded-gpt
+if version.parse(triton.__version__) < version.parse("3.6"):
+
+    # adatped from triton 3.6+
+    @triton.jit
+    def xcd_swizzle(pid, domain_size, XCD_SWIZZLE: tl.constexpr):
+        """
+        Swizzle the program id based on integer XCD_SWIZZLE.
+        This is useful for reording how blocks are ordered. A scheduler may, for example,
+        assign sequential blocks 0, 1, 2, 3, ..., 8, 9, 10.. to its 8 hardware units 0, 1, 2, 3, ..., 0, 1, 2.
+        This pattern may not be ideal for memory access, and it may be better to swizzle so the assignment
+        becomes 0, 0, 0, 0, ..., 1, 1, 1, ... In the swizzled arrangement, sequential blocks are assigned to
+        the same hardware unit.
+        """
+        # Number of pids per group in the new arrangement
+        pids_per_group = domain_size // XCD_SWIZZLE
+        extra_pid_groups = domain_size % XCD_SWIZZLE
+
+        # Compute current current and local pid within the group
+        group = pid % XCD_SWIZZLE
+        local_pid = pid // XCD_SWIZZLE
+
+        # Calculate new pid based on the new grouping
+        new_pid = group * pids_per_group + min(group, extra_pid_groups) + local_pid
+        return new_pid
+
+
+    @triton.jit
+    def swizzle2d(pid, grid_m, grid_n, GROUP_M: tl.constexpr):
+        width = GROUP_M * grid_n
+
+        group_id = pid // width
+        first_pid_m = group_id * GROUP_M
+        group_size = min(grid_m - first_pid_m, GROUP_M)
+        tl.assume(group_size >= 0)
+        pid_m = first_pid_m + (pid % group_size)
+        pid_n = (pid % width) // (group_size)
+        return pid_m, pid_n
+    
+    # NOTE (yiakwy) : FIX newer triton API
+    setattr(tl, 'swizzle2d', swizzle2d)
+    setattr(tl, 'xcd_swizzle', xcd_swizzle)
+    
+
+# Adpated from gemm swizzle by @byronxu99 for reference
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out


### PR DESCRIPTION
## Triton 3.5 Symm

#### Implement fp8 of X*XT and XT*X with TMA support

Add gluon xxt TMA baseline
<img width="1061" height="552" alt="截屏2026-07-20 15 50 31" src="https://github.com/user-attachments/assets/222a4fa1-3328-44df-99d3-f30968e0a27a" />

This demonstrate our optimized  CUDA (c++) is faster than the kernel used in **modded_gpt** (1200 vs 1040) , and TMA can acclerate triton implementation.

Test env :

torch : 2.10 + cuda12.8/cuda13.0 (driver 580+)
triton 3.5/3.6

#### add new version tvm ffi interface
see https://github.com/yiakwy-xpu-ml-framework-team/flash-float-jit-kernels/pull/11

#### fix tvm ffi triton 3.4 bug
<img width="953" height="151" alt="截屏2026-07-20 17 50 02" src="https://github.com/user-attachments/assets/72f27851-429e-48c4-90ea-40fc18a5a2e0" />


#### add our new sched 
not planned in this PR