### PR TITLE
Add Triton 3.5 baseline benchmarks and TVM-FFI path

### DIFF
--- a/jit_kernel/triton3_5/bench_fp8_gemm_block_scaled.py
+++ b/jit_kernel/triton3_5/bench_fp8_gemm_block_scaled.py
@@ -1,0 +1,232 @@
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+import triton
+import triton.testing
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from jit_kernel.triton3_5.symm_gemm import fp8_gemm_block_scaled
+
+
+DTYPES = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+}
+
+
+def parse_sizes(value: str) -> List[int]:
+    sizes = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not sizes:
+        raise argparse.ArgumentTypeError("expected at least one matrix size")
+    return sizes
+
+
+def selected_modes(mode: str) -> Iterable[str]:
+    if mode == "both":
+        return ("full", "symm")
+    return (mode,)
+
+
+def make_problem(
+    m: int,
+    n: int,
+    k: int,
+    mode: str,
+    dtype: torch.dtype,
+    scale_block_size_n: int,
+    scale_block_size_k: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    x = torch.randn((m, k), device="cuda", dtype=dtype)
+    xq = x.to(torch.float8_e4m3fn)
+
+    if mode == "symm":
+        wq = xq
+        n = m
+    else:
+        w = torch.randn((n, k), device="cuda", dtype=dtype)
+        wq = w.to(torch.float8_e4m3fn)
+
+    xs = torch.ones(
+        (m, triton.cdiv(k, scale_block_size_k)),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    ws = torch.ones(
+        (triton.cdiv(n, scale_block_size_n), triton.cdiv(k, scale_block_size_k)),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    return xq, wq, xs, ws
+
+
+def reference(xq: torch.Tensor, wq: torch.Tensor) -> torch.Tensor:
+    return torch.matmul(xq.float(), wq.float().T)
+
+
+def check_result(
+    xq: torch.Tensor,
+    wq: torch.Tensor,
+    xs: torch.Tensor,
+    ws: torch.Tensor,
+    is_symm: bool,
+    scale_block_size_n: int,
+    scale_block_size_k: int,
+) -> None:
+    out = fp8_gemm_block_scaled(
+        xq,
+        wq,
+        xs,
+        ws,
+        SCALE_BLOCK_SIZE_N=scale_block_size_n,
+        SCALE_BLOCK_SIZE_K=scale_block_size_k,
+        is_symm=is_symm,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        out.float(),
+        reference(xq, wq),
+        rtol=5e-2,
+        atol=1.0,
+    )
+
+
+def launch_grid_hint(m: int, n: int, mode: str) -> str:
+    if mode == "symm":
+        grid_m = triton.cdiv(m, 128)
+        grid_n = triton.cdiv(n, 128)
+        total_tiles = (grid_m * grid_n + grid_m) // 2
+    else:
+        # The full kernel autotunes between two block-N values, so this is a
+        # stable upper-level task count rather than a selected-config detail.
+        grid_m = triton.cdiv(m, 64)
+        grid_n = triton.cdiv(n, 128)
+        total_tiles = grid_m * grid_n
+    return f"total_tiles={total_tiles}"
+
+
+def bench_one(
+    mode: str,
+    m: int,
+    n: int,
+    k: int,
+    dtype: torch.dtype,
+    warmup: int,
+    rep: int,
+    do_check: bool,
+    scale_block_size_n: int,
+    scale_block_size_k: int,
+) -> float:
+    if mode == "symm":
+        n = m
+
+    xq, wq, xs, ws = make_problem(
+        m,
+        n,
+        k,
+        mode,
+        dtype,
+        scale_block_size_n,
+        scale_block_size_k,
+    )
+    is_symm = mode == "symm"
+
+    if do_check:
+        check_result(
+            xq,
+            wq,
+            xs,
+            ws,
+            is_symm,
+            scale_block_size_n,
+            scale_block_size_k,
+        )
+
+    fp8_gemm_block_scaled(
+        xq,
+        wq,
+        xs,
+        ws,
+        SCALE_BLOCK_SIZE_N=scale_block_size_n,
+        SCALE_BLOCK_SIZE_K=scale_block_size_k,
+        is_symm=is_symm,
+    )
+    torch.cuda.synchronize()
+
+    ms = triton.testing.do_bench(
+        lambda: fp8_gemm_block_scaled(
+            xq,
+            wq,
+            xs,
+            ws,
+            SCALE_BLOCK_SIZE_N=scale_block_size_n,
+            SCALE_BLOCK_SIZE_K=scale_block_size_k,
+            is_symm=is_symm,
+        ),
+        warmup=warmup,
+        rep=rep,
+    )
+    print(
+        f"{mode:5s} m={m:<5d} n={n:<5d} k={k:<5d} "
+        f"{launch_grid_hint(m, n, mode)} ms={ms:.6f}"
+    )
+    return float(ms)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark jit_kernel.triton3_5.symm_gemm.fp8_gemm_block_scaled."
+    )
+    parser.add_argument("--sizes", type=parse_sizes, default=parse_sizes("2048,4096,8192"))
+    parser.add_argument("--n", type=int, default=None)
+    parser.add_argument("--k", type=int, default=None)
+    parser.add_argument("--dtype", choices=DTYPES.keys(), default="fp16")
+    parser.add_argument("--mode", choices=("full", "symm", "both"), default="both")
+    parser.add_argument("--symm", action="store_true", help="Shortcut for --mode symm.")
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--rep", type=int, default=100)
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--scale-block-size-n", type=int, default=128)
+    parser.add_argument("--scale-block-size-k", type=int, default=128)
+    args = parser.parse_args()
+
+    if args.symm:
+        args.mode = "symm"
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark")
+
+    print("torch", torch.__version__, torch.version.cuda)
+    print("triton", triton.__version__)
+    print("gpu", torch.cuda.get_device_name(0))
+    print("capability", torch.cuda.get_device_capability(0))
+
+    dtype = DTYPES[args.dtype]
+    for mode in selected_modes(args.mode):
+        for m in args.sizes:
+            n = args.n if args.n is not None else m
+            k = args.k if args.k is not None else m
+            bench_one(
+                mode=mode,
+                m=m,
+                n=n,
+                k=k,
+                dtype=dtype,
+                warmup=args.warmup,
+                rep=args.rep,
+                do_check=args.check,
+                scale_block_size_n=args.scale_block_size_n,
+                scale_block_size_k=args.scale_block_size_k,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/jit_kernel/triton3_5/bench_symm_gemm.py
+++ b/jit_kernel/triton3_5/bench_symm_gemm.py
@@ -1,0 +1,160 @@
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+import torch
+import triton
+import triton.testing
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import jit_kernel.triton3_5.symm_gemm as symm_gemm
+
+
+DTYPES = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+}
+
+
+def parse_sizes(value: str) -> List[int]:
+    sizes = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not sizes:
+        raise argparse.ArgumentTypeError("expected at least one matrix size")
+    return sizes
+
+
+def make_input(m: int, k: int, batch_size: int, dtype: torch.dtype) -> torch.Tensor:
+    shape = (batch_size, m, k) if batch_size > 1 else (m, k)
+    return torch.randn(shape, device="cuda", dtype=dtype)
+
+
+def make_output(a: torch.Tensor, m: int, batch_size: int, dtype: torch.dtype) -> torch.Tensor:
+    shape = (batch_size, m, m) if batch_size > 1 else (m, m)
+    return torch.empty(shape, device=a.device, dtype=dtype)
+
+
+def check_result(a: torch.Tensor, out: torch.Tensor, use_tvm_ffi: bool) -> None:
+    out.zero_()
+    symm_gemm.XXT(a, out, use_tvm_ffi=use_tvm_ffi)
+    torch.cuda.synchronize()
+
+    ref = torch.matmul(a.float(), a.float().transpose(-1, -2))
+    torch.testing.assert_close(out.float(), ref, rtol=5e-2, atol=5e-1)
+
+
+def sentinel_check(a: torch.Tensor, out: torch.Tensor) -> None:
+    sentinel = -1234.0
+    symm_gemm.tvm_ffi_modules["XXT"] = None
+
+    out.fill_(sentinel)
+    symm_gemm.XXT(a, out, use_tvm_ffi=True)
+    torch.cuda.synchronize()
+    first_remaining = int((out == sentinel).sum().item())
+
+    out.fill_(sentinel)
+    symm_gemm.XXT(a, out, use_tvm_ffi=True)
+    torch.cuda.synchronize()
+    cached_remaining = int((out == sentinel).sum().item())
+
+    print(
+        f"sentinel: first_remaining={first_remaining}, "
+        f"cached_remaining={cached_remaining}, total={out.numel()}"
+    )
+
+
+def bench_one(
+    launcher: str,
+    m: int,
+    k: int,
+    batch_size: int,
+    dtype: torch.dtype,
+    warmup: int,
+    rep: int,
+    do_check: bool,
+    do_sentinel: bool,
+) -> float:
+    use_tvm_ffi = launcher == "tvm_ffi"
+    a = make_input(m, k, batch_size, dtype)
+    out = make_output(a, m, batch_size, dtype)
+
+    block_m, block_n, block_k, num_stages, num_warps = symm_gemm._xxt_config(k)
+    grid = batch_size * triton.cdiv(m, block_m) * triton.cdiv(m, block_n)
+
+    if do_check:
+        check_result(a, out, use_tvm_ffi)
+
+    if do_sentinel:
+        if not use_tvm_ffi:
+            raise ValueError("--sentinel only applies to --launcher tvm_ffi or both")
+        sentinel_check(a, out)
+
+    symm_gemm.XXT(a, out, use_tvm_ffi=use_tvm_ffi)
+    torch.cuda.synchronize()
+
+    ms = triton.testing.do_bench(
+        lambda: symm_gemm.XXT(a, out, use_tvm_ffi=use_tvm_ffi),
+        warmup=warmup,
+        rep=rep,
+    )
+    print(
+        f"{launcher:8s} m={m:<5d} k={k:<5d} batch={batch_size:<3d} "
+        f"grid=({grid},1,1) block=({num_warps * 32},1,1) "
+        f"bm={block_m} bn={block_n} bk={block_k} ms={ms:.6f}"
+    )
+    return float(ms)
+
+
+def selected_launchers(name: str) -> Iterable[str]:
+    if name == "both":
+        return ("native", "tvm_ffi")
+    return (name,)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark jit_kernel.triton3_5.symm_gemm.XXT."
+    )
+    parser.add_argument("--sizes", type=parse_sizes, default=parse_sizes("2048,4096,8192"))
+    parser.add_argument("--k", type=int, default=768)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--dtype", choices=DTYPES.keys(), default="fp16")
+    parser.add_argument("--launcher", choices=("native", "tvm_ffi", "both"), default="native")
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--rep", type=int, default=100)
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--sentinel", action="store_true")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark")
+
+    print("torch", torch.__version__, torch.version.cuda)
+    print("triton", triton.__version__)
+    print("gpu", torch.cuda.get_device_name(0))
+    print("capability", torch.cuda.get_device_capability(0))
+    print("USE_TVM_FFI default", symm_gemm.USE_TVM_FFI)
+
+    dtype = DTYPES[args.dtype]
+    for launcher in selected_launchers(args.launcher):
+        for m in args.sizes:
+            bench_one(
+                launcher=launcher,
+                m=m,
+                k=args.k,
+                batch_size=args.batch_size,
+                dtype=dtype,
+                warmup=args.warmup,
+                rep=args.rep,
+                do_check=args.check,
+                do_sentinel=args.sentinel and launcher == "tvm_ffi",
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/jit_kernel/triton3_5/bench_thunder_moun_gemm.py
+++ b/jit_kernel/triton3_5/bench_thunder_moun_gemm.py
@@ -1,0 +1,156 @@
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+import torch
+import triton
+import triton.testing
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from jit_kernel.triton3_5.symm_gemm import thunder_moun_gemm
+
+
+DTYPES = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+}
+
+
+def parse_sizes(value: str) -> List[int]:
+    sizes = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not sizes:
+        raise argparse.ArgumentTypeError("expected at least one matrix size")
+    return sizes
+
+
+def make_problem(
+    m: int,
+    k: int,
+    dtype: torch.dtype,
+    scale_block_size_n: int,
+    scale_block_size_k: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    x = torch.randn((m, k), device="cuda", dtype=dtype)
+    xq = x.to(torch.float8_e4m3fn)
+
+    xs_0 = torch.ones(
+        (m, triton.cdiv(k, scale_block_size_k)),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    xs_1 = torch.ones(
+        (triton.cdiv(m, scale_block_size_n), triton.cdiv(k, scale_block_size_k)),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    return xq, xq, xs_0, xs_1
+
+
+def reference(xq_lhs: torch.Tensor, xq_rhs: torch.Tensor) -> torch.Tensor:
+    return torch.matmul(xq_lhs.float(), xq_rhs.float().T)
+
+
+def check_result(
+    xq_lhs: torch.Tensor,
+    xq_rhs: torch.Tensor,
+    xs_0: torch.Tensor,
+    xs_1: torch.Tensor,
+    split_k: int,
+) -> None:
+    out = thunder_moun_gemm(xq_lhs, xq_rhs, xs_0, xs_1, SPLIT_K=split_k)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        out.float(),
+        reference(xq_lhs, xq_rhs),
+        rtol=5e-2,
+        atol=1.0,
+    )
+
+
+def bench_one(
+    m: int,
+    k: int,
+    dtype: torch.dtype,
+    warmup: int,
+    rep: int,
+    do_check: bool,
+    split_k: int,
+    scale_block_size_n: int,
+    scale_block_size_k: int,
+) -> float:
+    xq_lhs, xq_rhs, xs_0, xs_1 = make_problem(
+        m,
+        k,
+        dtype,
+        scale_block_size_n,
+        scale_block_size_k,
+    )
+
+    if do_check:
+        check_result(xq_lhs, xq_rhs, xs_0, xs_1, split_k)
+
+    thunder_moun_gemm(xq_lhs, xq_rhs, xs_0, xs_1, SPLIT_K=split_k)
+    torch.cuda.synchronize()
+
+    ms = triton.testing.do_bench(
+        lambda: thunder_moun_gemm(xq_lhs, xq_rhs, xs_0, xs_1, SPLIT_K=split_k),
+        warmup=warmup,
+        rep=rep,
+    )
+
+    grid_y = triton.cdiv(m // 2, 128)
+    print(
+        f"thunder_moun m={m:<5d} k={k:<5d} "
+        f"grid=({split_k},{grid_y},1) ms={ms:.6f}"
+    )
+    return float(ms)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark jit_kernel.triton3_5.symm_gemm.thunder_moun_gemm."
+    )
+    parser.add_argument("--sizes", type=parse_sizes, default=parse_sizes("2048,4096,8192"))
+    parser.add_argument("--k", type=int, default=None)
+    parser.add_argument("--dtype", choices=DTYPES.keys(), default="fp16")
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--rep", type=int, default=100)
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--split-k", type=int, default=1)
+    parser.add_argument("--scale-block-size-n", type=int, default=128)
+    parser.add_argument("--scale-block-size-k", type=int, default=128)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark")
+
+    print("torch", torch.__version__, torch.version.cuda)
+    print("triton", triton.__version__)
+    print("gpu", torch.cuda.get_device_name(0))
+    print("capability", torch.cuda.get_device_capability(0))
+
+    dtype = DTYPES[args.dtype]
+    for m in args.sizes:
+        k = args.k if args.k is not None else m
+        bench_one(
+            m=m,
+            k=k,
+            dtype=dtype,
+            warmup=args.warmup,
+            rep=args.rep,
+            do_check=args.check,
+            split_k=args.split_k,
+            scale_block_size_n=args.scale_block_size_n,
+            scale_block_size_k=args.scale_block_size_k,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/jit_kernel/triton3_5/symm_gemm.py
+++ b/jit_kernel/triton3_5/symm_gemm.py
@@ -11,6 +11,35 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 
 from packaging import version
 
+USE_TVM_FFI = False
+
+tvm_ffi_modules = {
+    "XXT": None,
+    "fp8_gemm_block_scaled": None,
+    "thunder_moun_gemm": None,
+}
+
+
+def is_hopper():
+    return triton.runtime.driver.active.get_current_target().arch >= 90
+
+
+if is_hopper():
+    NUM_XCDS = 1
+    OCP_FP8E4M3_MAX = 448.0
+    FP8_MAX = OCP_FP8E4M3_MAX
+
+    props = torch.cuda.get_device_properties(0)
+    SMs = props.multi_processor_count
+    NUM_CUs = SMs
+else:
+    raise Exception("Not supported yet!")
+
+
+class LoadBalanceStrategy(Enum):
+    UNDEFINE = -1
+    GAUSSIAN_FOLDING = 0
+
 
 # NOTE (yiakwy) : useful for multiple-die chiplet architecture :
 #   - Blackwell(2 dies), Rubin(2 dies),
@@ -64,6 +93,400 @@ def _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M):
     return pid_m, pid_n
 
 
+@triton.jit
+def _symm_moun_mat_compute(
+    pid_m_pair,
+    pid_m,
+    pid_n,
+    acc,
+    acc_pair,
+    xq_ptr,
+    wq_ptr,
+    xs_lhs_ptr,
+    xs_rhs_ptr,
+    o_ptr,
+    M,
+    K,
+    stride_xq_m,
+    stride_xq_k,
+    stride_wq_n,
+    stride_wq_k,
+    stride_xs_m,
+    stride_xs_k,
+    stride_ws_n,
+    stride_ws_k,
+    stride_o_m,
+    stride_o_n,
+    offs_k,
+    start_ssteps,
+    num_ssteps,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    SCALE_BLOCK_SIZE_N,
+    SCALE_BLOCK_SIZE_K,
+    SPLIT_K,
+):
+    offs_xq_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_xq_pair_m = (pid_m_pair * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+
+    if BLOCK_SIZE_M != BLOCK_SIZE_N or pid_m != pid_n:
+        offs_wq_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % M
+    else:
+        offs_wq_n = offs_xq_m
+
+    xq_block_ptr = xq_ptr + (
+        offs_xq_m[:, None] * stride_xq_m + offs_k[None, :] * stride_xq_k
+    )
+    xq_pair_block_ptr = xq_ptr + (
+        offs_xq_pair_m[:, None] * stride_xq_m + offs_k[None, :] * stride_xq_k
+    )
+
+    wq_block_ptr = wq_ptr + (
+        offs_wq_n[:, None] * stride_wq_n + offs_k[None, :] * stride_wq_k
+    )
+
+    xs_block_ptr = (
+        xs_lhs_ptr
+        + offs_xq_m * stride_xs_m
+        + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+    )
+    xs_pair_block_ptr = (
+        xs_lhs_ptr
+        + offs_xq_pair_m * stride_xs_m
+        + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+    )
+
+    offs_ws_n = offs_wq_n // SCALE_BLOCK_SIZE_N
+    ws_block_ptr = (
+        xs_rhs_ptr
+        + offs_ws_n * stride_ws_n
+        + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+    )
+
+    xq = tl.load(
+        xq_block_ptr,
+        mask=offs_k[None, :] < K,
+        other=0.0,
+    )
+
+    xq_pair = xq
+    if pid_m_pair >= pid_n:
+        xq_pair = tl.load(
+            xq_pair_block_ptr,
+            mask=offs_k[None, :] < K,
+            other=0.0,
+        )
+
+    wq = tl.load(
+        wq_block_ptr,
+        mask=offs_k[None, :] < K,
+        other=0.0,
+    )
+
+    xs = tl.load(xs_block_ptr)
+
+    xs_pair = xs
+    if pid_n <= pid_m_pair:
+        xs_pair = tl.load(xs_pair_block_ptr)
+
+    ws = tl.load(ws_block_ptr)
+
+    xq_next = xq
+    wq_next = wq
+
+    xs_next = xs
+    ws_next = ws
+
+    xq_pair_next = xq_pair
+    xs_pair_next = xs_pair
+
+    last_ssteps = start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+    end_ssteps = start_ssteps + num_ssteps
+    for k in tl.range(start_ssteps, end_ssteps):
+        xq_k_step = BLOCK_SIZE_K * stride_xq_k
+        wq_k_step = BLOCK_SIZE_K * stride_wq_k
+
+        cur_ssteps = (k + 1) * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+        if k + 1 < end_ssteps:
+            xq_next = tl.load(
+                xq_block_ptr + xq_k_step,
+                mask=offs_k[None, :] < K - (k + 1) * (BLOCK_SIZE_K),
+                other=0.0,
+            )
+
+            wq_next = tl.load(
+                wq_block_ptr + wq_k_step,
+                mask=offs_k[None, :] < K - (k + 1) * (BLOCK_SIZE_K),
+                other=0.0,
+            )
+
+            if cur_ssteps > last_ssteps:
+                xs_next = tl.load(xs_block_ptr + stride_xs_k)
+                ws_next = tl.load(ws_block_ptr + stride_ws_k)
+
+        acc += tl.dot(xq, wq.trans(1, 0), input_precision="ieee") * (
+            xs[:, None] * ws[None, :]
+        )
+
+        if pid_m_pair >= pid_n:
+            if k + 1 < end_ssteps:
+                xq_pair_next = tl.load(
+                    xq_pair_block_ptr + xq_k_step,
+                    mask=offs_k[None, :] < K - (k + 1) * (BLOCK_SIZE_K),
+                    other=0.0,
+                )
+                xs_pair_next = tl.load(xs_pair_block_ptr + stride_xs_k)
+
+            acc_pair += tl.dot(xq_pair, wq.trans(1, 0), input_precision="ieee") * (
+                xs_pair[:, None] * ws[None, :]
+            )
+
+        xq_block_ptr += xq_k_step
+        wq_block_ptr += wq_k_step
+
+        if cur_ssteps > last_ssteps:
+            xs_block_ptr += stride_xs_k
+            ws_block_ptr += stride_ws_k
+
+        if k + 1 < end_ssteps:
+            xq = xq_next
+            wq = wq_next
+
+            if cur_ssteps > last_ssteps:
+                xs = xs_next
+                ws = ws_next
+
+        if pid_m_pair >= pid_n:
+            xq_pair_block_ptr += xq_k_step
+
+            if cur_ssteps > last_ssteps:
+                xs_pair_block_ptr += stride_xs_k
+
+            if k + 1 < end_ssteps:
+                xq_pair = xq_pair_next
+
+                if cur_ssteps > last_ssteps:
+                    xs_pair = xs_pair_next
+
+        last_ssteps = cur_ssteps
+
+    if acc.dtype != o_ptr.type.element_ty:
+        _acc = acc.to(o_ptr.type.element_ty)
+    else:
+        _acc = acc
+    o_block_ptr = (
+        o_ptr + offs_xq_m[:, None] * stride_o_m + offs_wq_n[None, :] * stride_o_n
+    )
+    o_mask = (offs_xq_m[:, None] < M) & (offs_wq_n[None, :] < M)
+    if SPLIT_K == 1:
+        tl.store(o_block_ptr, _acc, mask=o_mask)
+    else:
+        tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+    if pid_n < pid_m:
+        _acc = tl.trans(_acc, 1, 0)
+        o_block_ptr = (
+            o_ptr + offs_wq_n[:, None] * stride_o_m + offs_xq_m[None, :] * stride_o_n
+        )
+        o_mask = (offs_wq_n[:, None] < M) & (offs_xq_m[None, :] < M)
+        if SPLIT_K == 1:
+            tl.store(o_block_ptr, _acc, mask=o_mask)
+        else:
+            tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+    if pid_n <= pid_m_pair:
+        if acc_pair.dtype != o_ptr.type.element_ty:
+            _acc = acc_pair.to(o_ptr.type.element_ty)
+        else:
+            _acc = acc_pair
+        o_pair_block_ptr = (
+            o_ptr
+            + offs_xq_pair_m[:, None] * stride_o_m
+            + offs_wq_n[None, :] * stride_o_n
+        )
+        o_mask_pair = (offs_xq_pair_m[:, None] < M) & (offs_wq_n[None, :] < M)
+        if SPLIT_K == 1:
+            tl.store(o_pair_block_ptr, _acc, mask=o_mask_pair)
+        else:
+            tl.atomic_add(o_pair_block_ptr, _acc, mask=o_mask_pair)
+
+        if pid_n < pid_m_pair:
+            _acc = tl.trans(_acc, 1, 0)
+            o_pair_block_ptr = (
+                o_ptr
+                + offs_wq_n[:, None] * stride_o_m
+                + offs_xq_pair_m[None, :] * stride_o_n
+            )
+            o_mask_pair = (offs_wq_n[:, None] < M) & (offs_xq_pair_m[None, :] < M)
+            if SPLIT_K == 1:
+                tl.store(o_pair_block_ptr, _acc, mask=o_mask_pair)
+            else:
+                tl.atomic_add(o_pair_block_ptr, _acc, mask=o_mask_pair)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 1,
+            },
+            num_stages=2,
+            num_warps=8,
+            maxnreg=384,
+        ),
+    ],
+    key=("M", "K"),
+    use_cuda_graph=True,
+)
+@triton.heuristics(
+    {
+        "NUM_PID_M": lambda args: triton.cdiv(args["M"] // 2, args["BLOCK_SIZE_M"]),
+        "SPLIT_K": lambda args: args.get("SPLIT_K", 1),
+    }
+)
+@triton.jit
+def paired_symm_moun_mat_fp8_block_scaled_tuned_kernel(
+    xq_ptr,
+    wq_ptr,
+    o_ptr,
+    M,
+    K,
+    stride_xq_m,
+    stride_xq_k,
+    stride_o_m,
+    stride_o_n,
+    xs_lhs_ptr,
+    xs_rhs_ptr,
+    stride_xs_lhs_m,
+    stride_xs_lhs_k,
+    stride_xs_rhs_n,
+    stride_xs_rhs_k,
+    SCALE_BLOCK_SIZE_K: tl.constexpr,
+    SCALE_BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    NUM_CUs: tl.constexpr,
+    NUM_PID_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    M_EVEN: tl.constexpr,
+):
+    pid_k = tl.program_id(axis=0)
+    pid_m = tl.program_id(axis=1)
+
+    num_pid_m = NUM_PID_M
+
+    if M_EVEN:
+        FULL_BLOCKS = num_pid_m * 2 - 1
+    else:
+        FULL_BLOCKS = num_pid_m * 2
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    num_ssteps = tl.cdiv(K, BLOCK_SIZE_K * SPLIT_K)
+
+    start_ssteps = pid_k * num_ssteps
+    offs_k += start_ssteps * BLOCK_SIZE_K
+
+    acc_dtype = tl.float32
+
+    pid_m_pair = FULL_BLOCKS - pid_m
+    for pid_n in tl.range(0, pid_m_pair + 1):
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+        acc_pair = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+
+        _symm_moun_mat_compute(
+            pid_m,
+            pid_m_pair,
+            pid_n,
+            acc,
+            acc_pair,
+            xq_ptr,
+            wq_ptr,
+            xs_lhs_ptr,
+            xs_rhs_ptr,
+            o_ptr,
+            M,
+            K,
+            stride_xq_m,
+            stride_xq_k,
+            stride_xq_m,
+            stride_xq_k,
+            stride_xs_lhs_m,
+            stride_xs_lhs_k,
+            stride_xs_rhs_n,
+            stride_xs_rhs_k,
+            stride_o_m,
+            stride_o_n,
+            offs_k,
+            start_ssteps,
+            num_ssteps,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            SCALE_BLOCK_SIZE_N,
+            SCALE_BLOCK_SIZE_K,
+            SPLIT_K,
+        )
+
+
+def thunder_moun_gemm(
+    xq_lhs: torch.Tensor,
+    xq_rhs: torch.Tensor,
+    xs_0: torch.Tensor,
+    xs_1: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    online_quant: bool = False,
+    SPLIT_K: int = 1,
+    use_tvm_ffi: Optional[bool] = None,
+):
+    use_ffi = USE_TVM_FFI if use_tvm_ffi is None else use_tvm_ffi
+    if use_ffi:
+        raise NotImplementedError(
+            "Triton 3.5 thunder_moun_gemm TVM-FFI launcher is not wired yet. "
+            "Use native first, then add the launcher after native is validated."
+        )
+
+    M, K = xq_lhs.shape
+    if out is None:
+        out = torch.zeros((M, M), device=xq_lhs.device, dtype=torch.float16)
+
+    grid = lambda META: (SPLIT_K, triton.cdiv(M // 2, META["BLOCK_SIZE_M"]), 1)
+    kernel = paired_symm_moun_mat_fp8_block_scaled_tuned_kernel
+
+    kernel[grid](
+        xq_lhs,
+        xq_rhs,
+        out,
+        M,
+        K,
+        xq_lhs.stride(0),
+        xq_lhs.stride(1),
+        out.stride(0),
+        out.stride(1),
+        xs_0,
+        xs_1,
+        xs_0.stride(0),
+        xs_0.stride(1),
+        xs_1.stride(0),
+        xs_1.stride(1),
+        SCALE_BLOCK_SIZE_K=128,
+        SCALE_BLOCK_SIZE_N=128,
+        NUM_XCDS=NUM_XCDS,
+        NUM_CUs=NUM_CUs,
+        SPLIT_K=SPLIT_K,
+        M_EVEN=M % 2 == 0,
+    )
+
+    return out
+
+
 # Ref kernels are adpated from modded-gpt
 if version.parse(triton.__version__) < version.parse("3.6"):
 
@@ -92,7 +515,8 @@ if version.parse(triton.__version__) < version.parse("3.6"):
 
 
     @triton.jit
-    def swizzle2d(pid, grid_m, grid_n, GROUP_M: tl.constexpr):
+    def swizzle2d(i, j, grid_m, grid_n, GROUP_M: tl.constexpr):
+        pid = i * grid_n + j
         width = GROUP_M * grid_n
 
         group_id = pid // width
@@ -100,7 +524,7 @@ if version.parse(triton.__version__) < version.parse("3.6"):
         group_size = min(grid_m - first_pid_m, GROUP_M)
         tl.assume(group_size >= 0)
         pid_m = first_pid_m + (pid % group_size)
-        pid_n = (pid % width) // (group_size)
+        pid_n = (pid % width) // group_size
         return pid_m, pid_n
     
     # NOTE (yiakwy) : FIX newer triton API
@@ -202,7 +626,753 @@ def XXT_kernel(
     tl.store(c_ptrs_t, output.T, mask=c_mask_t)
 
 
-def XXT(A: torch.Tensor, out: torch.Tensor):
+def get_pack_size(
+    pack_int8=False,
+    pack_int16=False,
+    pack_int32=False,
+):
+    if pack_int8:
+        return 8
+    if pack_int16:
+        return 16
+    if pack_int32:
+        return 32
+    return 1
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 64,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 16,
+                "NUM_STAGES": 3,
+            },
+            num_stages=3,
+            num_warps=16,
+            maxnreg=384,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 64,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 64,
+                "GROUP_SIZE_M": 16,
+                "NUM_STAGES": 3,
+            },
+            num_stages=3,
+            num_warps=8,
+            maxnreg=384,
+        ),
+    ],
+    key=("M", "N", "K"),
+    use_cuda_graph=False,
+)
+@triton.heuristics(
+    {
+        "GRID_MN": lambda args: triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+        * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+        "BLOCKS_PER_XCD": lambda args: triton.cdiv(
+            triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+            * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+            NUM_XCDS,
+        ),
+        "NUM_PID_M": lambda args: triton.cdiv(args["M"], args["BLOCK_SIZE_M"]),
+        "NUM_PID_N": lambda args: triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+        "SPLIT_K": lambda _: 1,
+        "w1a16": lambda args: args.get("pack_int8", False)
+        or args.get("pack_int16", False)
+        or args.get("pack_int32", False),
+        "packed_size": lambda args: get_pack_size(
+            pack_int8=args.get("pack_int8", False),
+            pack_int16=args.get("pack_int16", False),
+            pack_int32=args.get("pack_int32", False),
+        ),
+        "_is_hopper": lambda args: args.get("_is_hopper", is_hopper()),
+    }
+)
+@triton.jit
+def fp8_streamk_gemm_block_scaled_tuned_kernel(
+    xq_ptr,
+    wq_ptr,
+    o_ptr,
+    M,
+    N,
+    K,
+    stride_xq_m,
+    stride_xq_k,
+    stride_wq_n,
+    stride_wq_k,
+    stride_o_m,
+    stride_o_n,
+    xs_ptr,
+    ws_ptr,
+    stride_xs_m,
+    stride_xs_k,
+    stride_ws_n,
+    stride_ws_k,
+    SCALE_BLOCK_SIZE_K: tl.constexpr,
+    SCALE_BLOCK_SIZE_N: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_CUs: tl.constexpr,
+    GRID_MN: tl.constexpr,
+    BLOCKS_PER_XCD: tl.constexpr,
+    NUM_PID_M: tl.constexpr,
+    NUM_PID_N: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    w1a16: tl.constexpr,
+    packed_size: tl.constexpr,
+    use_w1a16_as_fp8: tl.constexpr,
+    use_w1a8: tl.constexpr,
+    _is_hopper: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+
+    num_pid_m = NUM_PID_M
+    num_pid_n = NUM_PID_N
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    if w1a16:
+        offs_k_packed = tl.arange(0, BLOCK_SIZE_K // packed_size)
+
+    num_ssteps = tl.cdiv(K, BLOCK_SIZE_K * SPLIT_K)
+
+    for tile_id_0 in tl.range(pid, GRID_MN * SPLIT_K, NUM_CUs):
+        tile_id = tile_id_0 % GRID_MN
+        pid_k = tile_id_0 // GRID_MN
+
+        start_ssteps = pid_k * num_ssteps
+        offs_k += start_ssteps * BLOCK_SIZE_K
+        if w1a16:
+            offs_k_packed += start_ssteps * BLOCK_SIZE_K // packed_size
+
+        pid_m, pid_n = _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+        offs_xq_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+        offs_wq_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+
+        xq_block_ptr = xq_ptr + (
+            offs_xq_m[:, None] * stride_xq_m + offs_k[None, :] * stride_xq_k
+        )
+        if w1a16:
+            unpack_offs = tl.arange(0, packed_size).to(wq_ptr.type.element_ty)
+
+            wq_block_ptr = wq_ptr + (
+                offs_wq_n[:, None] * stride_wq_n + offs_k_packed[None, :] * stride_wq_k
+            )
+
+        else:
+            wq_block_ptr = wq_ptr + (
+                offs_wq_n[:, None] * stride_wq_n + offs_k[None, :] * stride_wq_k
+            )
+
+            xs_block_ptr = (
+                xs_ptr
+                + offs_xq_m * stride_xs_m
+                + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            )
+
+            offs_ws_n = offs_wq_n // SCALE_BLOCK_SIZE_N
+            ws_block_ptr = (
+                ws_ptr
+                + offs_ws_n * stride_ws_n
+                + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            )
+
+        acc_dtype = tl.float16
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+
+        if not w1a16:
+            xs_next = tl.load(xs_block_ptr)
+            ws_next = tl.load(ws_block_ptr)
+
+        last_ssteps = start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+        for k in tl.range(
+            start_ssteps, start_ssteps + num_ssteps, num_stages=NUM_STAGES
+        ):
+            xq = tl.load(
+                xq_block_ptr,
+                mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+                other=0.0,
+            )
+
+            if w1a16:
+                wq = tl.load(
+                    wq_block_ptr,
+                    mask=offs_k_packed[None, :]
+                    < K // packed_size - k * (BLOCK_SIZE_K // packed_size),
+                    other=0.0,
+                )
+
+                wq = wq[:, :, None]
+
+                wq = tl.inline_asm_elementwise(
+                    asm="bfe.u32 $0, $1, $2, 1;",
+                    constraints="=r,r,r",
+                    args=[wq, unpack_offs[None, None, :]],
+                    dtype=wq_ptr.type.element_ty,
+                    is_pure=True,
+                    pack=1,
+                )
+
+                wq = wq.reshape((BLOCK_SIZE_N, BLOCK_SIZE_K))
+                wq = wq * 2 - 1
+                wq = wq.to(tl.float16)
+
+                if use_w1a16_as_fp8:
+                    wq = wq.to(tl.float8e4nv)
+                    xq = xq.to(tl.float8e4nv)
+                elif use_w1a8:
+                    wq = wq.to(tl.float8e4nv)
+
+            else:
+                wq = tl.load(
+                    wq_block_ptr,
+                    mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+                    other=0.0,
+                )
+
+                if wq.dtype == tl.int8 or wq.dtype == tl.int16:
+                    wq = wq.to(tl.float16)
+
+                    if use_w1a16_as_fp8:
+                        wq = wq.to(tl.float8e4nv)
+                        xq = xq.to(tl.float8e4nv)
+                    elif use_w1a8:
+                        wq = wq.to(tl.float8e4nv)
+
+            ws = ws_next
+            xs = xs_next
+
+            cur_ssteps = (k + 1) * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            if cur_ssteps > last_ssteps and (k + 1) < num_ssteps:
+                xs_next = tl.load(xs_block_ptr + stride_xs_k)
+                ws_next = tl.load(ws_block_ptr + stride_ws_k)
+
+            if w1a16:
+                acc = tl.dot(xq, wq.trans(1, 0), acc=acc, out_dtype=acc_dtype)
+            else:
+                if False:
+                    acc = tl.dot(
+                        xq * xs[:, None],
+                        (wq * ws[:, None]).trans(1, 0),
+                        acc=acc,
+                        input_precision="ieee",
+                        out_dtype=acc_dtype,
+                    )
+                else:
+                    acc += tl.dot(
+                        xq, wq.trans(1, 0), input_precision="ieee", out_dtype=acc_dtype
+                    ) * ((xs[:, None] * ws[None, :]).to(acc_dtype))
+
+            xq_block_ptr += BLOCK_SIZE_K * stride_xq_k
+            if w1a16:
+                wq_block_ptr += BLOCK_SIZE_K // packed_size * stride_wq_k
+            else:
+                wq_block_ptr += BLOCK_SIZE_K * stride_wq_k
+
+            if cur_ssteps > last_ssteps and (k + 1) < num_ssteps:
+                xs_block_ptr += stride_xs_k
+                ws_block_ptr += stride_ws_k
+
+            last_ssteps = cur_ssteps
+
+        o_block_ptr = (
+            o_ptr + offs_xq_m[:, None] * stride_o_m + offs_wq_n[None, :] * stride_o_n
+        )
+        o_mask = (offs_xq_m[:, None] < M) & (offs_wq_n[None, :] < N)
+
+        if o_ptr.type.element_ty != acc.dtype:
+            _acc = acc.to(o_ptr.type.element_ty)
+        else:
+            _acc = acc
+        if SPLIT_K == 1:
+            tl.store(o_block_ptr, _acc, mask=o_mask)
+        else:
+            tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 64,
+                "GROUP_SIZE_M": 16,
+                "NUM_STAGES": 3,
+            },
+            num_stages=3,
+            num_warps=8,
+            maxnreg=384,
+        ),
+    ],
+    key=("M", "N", "K"),
+    use_cuda_graph=False,
+)
+@triton.heuristics(
+    {
+        "GRID_MN": lambda args: (
+            triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+            * triton.cdiv(args["N"], args["BLOCK_SIZE_N"])
+            + triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+        )
+        // 2,
+        "BLOCKS_PER_XCD": lambda args: triton.cdiv(
+            triton.cdiv(args["M"], args["BLOCK_SIZE_M"])
+            * triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+            NUM_XCDS,
+        ),
+        "NUM_PID_M": lambda args: triton.cdiv(args["M"], args["BLOCK_SIZE_M"]),
+        "NUM_PID_N": lambda args: triton.cdiv(args["N"], args["BLOCK_SIZE_N"]),
+        "SPLIT_K": lambda _: 1,
+        "w1a16": lambda args: args.get("pack_int8", False)
+        or args.get("pack_int16", False)
+        or args.get("pack_int32", False),
+        "packed_size": lambda args: get_pack_size(
+            pack_int8=args.get("pack_int8", False),
+            pack_int16=args.get("pack_int16", False),
+            pack_int32=args.get("pack_int32", False),
+        ),
+        "_is_hopper": lambda args: args.get("_is_hopper", is_hopper()),
+        "_is_symm": lambda args: args.get("_is_symm", True),
+    }
+)
+@triton.jit
+def fp8_streamk_symm_gemm_block_scaled_tuned_kernel(
+    xq_ptr,
+    wq_ptr,
+    o_ptr,
+    M,
+    N,
+    K,
+    stride_xq_m,
+    stride_xq_k,
+    stride_wq_n,
+    stride_wq_k,
+    stride_o_m,
+    stride_o_n,
+    xs_ptr,
+    ws_ptr,
+    stride_xs_m,
+    stride_xs_k,
+    stride_ws_n,
+    stride_ws_k,
+    SCALE_BLOCK_SIZE_K: tl.constexpr,
+    SCALE_BLOCK_SIZE_N: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_CUs: tl.constexpr,
+    GRID_MN: tl.constexpr,
+    BLOCKS_PER_XCD: tl.constexpr,
+    NUM_PID_M: tl.constexpr,
+    NUM_PID_N: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    w1a16: tl.constexpr,
+    packed_size: tl.constexpr,
+    use_w1a16_as_fp8: tl.constexpr,
+    use_w1a8: tl.constexpr,
+    _is_hopper: tl.constexpr,
+    _is_symm: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+
+    num_pid_m = NUM_PID_M
+    num_pid_n = NUM_PID_N
+
+    tl.static_assert(
+        _is_symm,
+        "This streamk_symm_gemm kernel is designed for symmetric matrix multiplication, please set _is_symm to True.",
+    )
+    tl.static_assert(
+        NUM_PID_M == NUM_PID_N,
+        "The streamk_symm_gemm kernel currently only supports BLOCK_SIZE_M == BLOCK_SIZE_N.",
+    )
+
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    if w1a16:
+        offs_k_packed = tl.arange(0, BLOCK_SIZE_K // packed_size)
+
+    num_ssteps = tl.cdiv(K, BLOCK_SIZE_K * SPLIT_K)
+
+    for tile_id_0 in tl.range(pid, GRID_MN * SPLIT_K, NUM_CUs):
+        tile_id = tile_id_0 % GRID_MN
+        pid_k = tile_id_0 // GRID_MN
+
+        start_ssteps = pid_k * num_ssteps
+        offs_k += start_ssteps * BLOCK_SIZE_K
+        if w1a16:
+            offs_k_packed += start_ssteps * BLOCK_SIZE_K // packed_size
+
+        if _is_symm:
+            pid_m, pid_n = linear_to_tril(tile_id)
+        else:
+            pid_m, pid_n = _compute_pid(tile_id, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+        offs_xq_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+        offs_wq_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+
+        xq_block_ptr = xq_ptr + (
+            offs_xq_m[:, None] * stride_xq_m + offs_k[None, :] * stride_xq_k
+        )
+        if w1a16:
+            unpack_offs = tl.arange(0, packed_size).to(wq_ptr.type.element_ty)
+
+            wq_block_ptr = wq_ptr + (
+                offs_wq_n[:, None] * stride_wq_n + offs_k_packed[None, :] * stride_wq_k
+            )
+
+        else:
+            wq_block_ptr = wq_ptr + (
+                offs_wq_n[:, None] * stride_wq_n + offs_k[None, :] * stride_wq_k
+            )
+
+            xs_block_ptr = (
+                xs_ptr
+                + offs_xq_m * stride_xs_m
+                + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            )
+
+            offs_ws_n = offs_wq_n // SCALE_BLOCK_SIZE_N
+            ws_block_ptr = (
+                ws_ptr
+                + offs_ws_n * stride_ws_n
+                + start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            )
+
+        acc_dtype = tl.float16
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+
+        if not w1a16:
+            xs_next = tl.load(xs_block_ptr)
+            ws_next = tl.load(ws_block_ptr)
+
+        last_ssteps = start_ssteps * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+        for k in tl.range(
+            start_ssteps, start_ssteps + num_ssteps, num_stages=NUM_STAGES
+        ):
+            xq = tl.load(
+                xq_block_ptr,
+                mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+                other=0.0,
+            )
+
+            if w1a16:
+                wq = tl.load(
+                    wq_block_ptr,
+                    mask=offs_k_packed[None, :]
+                    < K // packed_size - k * (BLOCK_SIZE_K // packed_size),
+                    other=0.0,
+                )
+
+                wq = wq[:, :, None]
+
+                wq = tl.inline_asm_elementwise(
+                    asm="bfe.u32 $0, $1, $2, 1;",
+                    constraints="=r,r,r",
+                    args=[wq, unpack_offs[None, None, :]],
+                    dtype=wq_ptr.type.element_ty,
+                    is_pure=True,
+                    pack=1,
+                )
+
+                wq = wq.reshape((BLOCK_SIZE_N, BLOCK_SIZE_K))
+                wq = wq * 2 - 1
+                wq = wq.to(tl.float16)
+
+                if use_w1a16_as_fp8:
+                    wq = wq.to(tl.float8e4nv)
+                    xq = xq.to(tl.float8e4nv)
+                elif use_w1a8:
+                    wq = wq.to(tl.float8e4nv)
+
+            else:
+                wq = tl.load(
+                    wq_block_ptr,
+                    mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K),
+                    other=0.0,
+                )
+
+                if wq.dtype == tl.int8 or wq.dtype == tl.int16:
+                    wq = wq.to(tl.float16)
+
+                    if use_w1a16_as_fp8:
+                        wq = wq.to(tl.float8e4nv)
+                        xq = xq.to(tl.float8e4nv)
+                    elif use_w1a8:
+                        wq = wq.to(tl.float8e4nv)
+
+            ws = ws_next
+            xs = xs_next
+
+            cur_ssteps = (k + 1) * BLOCK_SIZE_K // SCALE_BLOCK_SIZE_K
+            if cur_ssteps > last_ssteps and (k + 1) < num_ssteps:
+                xs_next = tl.load(xs_block_ptr + stride_xs_k)
+                ws_next = tl.load(ws_block_ptr + stride_ws_k)
+
+            if w1a16:
+                acc = tl.dot(xq, wq.trans(1, 0), acc=acc, out_dtype=acc_dtype)
+            else:
+                if False:
+                    acc = tl.dot(
+                        xq * xs[:, None],
+                        (wq * ws[:, None]).trans(1, 0),
+                        acc=acc,
+                        input_precision="ieee",
+                        out_dtype=acc_dtype,
+                    )
+                else:
+                    acc += tl.dot(
+                        xq, wq.trans(1, 0), input_precision="ieee", out_dtype=acc_dtype
+                    ) * ((xs[:, None] * ws[None, :]).to(acc_dtype))
+
+            xq_block_ptr += BLOCK_SIZE_K * stride_xq_k
+            if w1a16:
+                wq_block_ptr += BLOCK_SIZE_K // packed_size * stride_wq_k
+            else:
+                wq_block_ptr += BLOCK_SIZE_K * stride_wq_k
+
+            if cur_ssteps > last_ssteps and (k + 1) < num_ssteps:
+                xs_block_ptr += stride_xs_k
+                ws_block_ptr += stride_ws_k
+
+            last_ssteps = cur_ssteps
+
+        o_block_ptr = (
+            o_ptr + offs_xq_m[:, None] * stride_o_m + offs_wq_n[None, :] * stride_o_n
+        )
+        o_mask = (offs_xq_m[:, None] < M) & (offs_wq_n[None, :] < N)
+
+        if o_ptr.type.element_ty != acc.dtype:
+            _acc = acc.to(o_ptr.type.element_ty)
+        else:
+            _acc = acc
+        if SPLIT_K == 1:
+            tl.store(o_block_ptr, _acc, mask=o_mask)
+        else:
+            tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+        if _is_symm:
+            if pid_n < pid_m:
+                _acc = tl.trans(_acc, 1, 0)
+                o_block_ptr = (
+                    o_ptr
+                    + offs_wq_n[:, None] * stride_o_m
+                    + offs_xq_m[None, :] * stride_o_n
+                )
+                o_mask = (offs_wq_n[:, None] < M) & (offs_xq_m[None, :] < M)
+                if SPLIT_K == 1:
+                    tl.store(o_block_ptr, _acc, mask=o_mask)
+                else:
+                    tl.atomic_add(o_block_ptr, _acc, mask=o_mask)
+
+
+def fp8_gemm_block_scaled(
+    xq: torch.Tensor,
+    wq: torch.Tensor,
+    xs: torch.Tensor,
+    ws: torch.Tensor,
+    o: Optional[torch.Tensor] = None,
+    SCALE_BLOCK_SIZE_N=128,
+    SCALE_BLOCK_SIZE_K=128,
+    check_input_shape=False,
+    is_symm=False,
+    use_tvm_ffi: Optional[bool] = None,
+):
+    if check_input_shape:
+        assert xq.dim() >= 2, "xq must be >= 2 dims"
+        assert wq.dim() >= 2, "wq must be >= 2 dims"
+
+        if xq.dim() > 2:
+            xq_flatten = xq.flatten(start_dim=1)
+            wq_flatten = wq.flatten(start_dim=1)
+
+            xq = xq_flatten
+            wq = wq_flatten
+
+        assert xq.shape[1] == wq.shape[1], "the shapes of xq and wq are incompatible!"
+
+    use_ffi = USE_TVM_FFI if use_tvm_ffi is None else use_tvm_ffi
+    if use_ffi:
+        raise NotImplementedError(
+            "Triton 3.5 fp8_gemm_block_scaled TVM-FFI launcher is not wired yet. "
+            "Use native first, then add the launcher after native is validated."
+        )
+
+    M, K = xq.shape
+    N = wq.shape[0]
+
+    if o is None:
+        o = torch.zeros((M, N), device=xq.device, dtype=torch.float16)
+
+    if is_symm:
+        grid = lambda META: (
+            min(
+                NUM_CUs,
+                (
+                    (
+                        triton.cdiv(M, META["BLOCK_SIZE_M"])
+                        * triton.cdiv(N, META["BLOCK_SIZE_N"])
+                        + triton.cdiv(M, META["BLOCK_SIZE_M"])
+                    )
+                    // 2
+                )
+                * META["SPLIT_K"],
+            ),
+        )
+
+        kernel = fp8_streamk_symm_gemm_block_scaled_tuned_kernel
+    else:
+        grid = lambda META: (
+            min(
+                NUM_CUs,
+                triton.cdiv(M, META["BLOCK_SIZE_M"])
+                * triton.cdiv(N, META["BLOCK_SIZE_N"])
+                * META["SPLIT_K"],
+            ),
+        )
+
+        kernel = fp8_streamk_gemm_block_scaled_tuned_kernel
+
+    kernel[grid](
+        xq,
+        wq,
+        o,
+        M,
+        N,
+        K,
+        xq.stride(0),
+        xq.stride(1),
+        wq.stride(0),
+        wq.stride(1),
+        o.stride(0),
+        o.stride(1),
+        xs,
+        ws,
+        xs.stride(0),
+        xs.stride(1),
+        ws.stride(0),
+        ws.stride(1),
+        SCALE_BLOCK_SIZE_N=SCALE_BLOCK_SIZE_N,
+        SCALE_BLOCK_SIZE_K=SCALE_BLOCK_SIZE_K,
+        NUM_XCDS=NUM_XCDS,
+        NUM_CUs=NUM_CUs,
+        use_w1a16_as_fp8=False,
+        use_w1a8=False,
+    )
+
+    return o
+
+
+def _xxt_config(K: int):
+    if K == 768:
+        return 128, 128, 64, 4, 8
+    return 64, 128, 128, 4, 8
+
+
+def _xxt_tvm_ffi(
+    A: torch.Tensor,
+    out: torch.Tensor,
+    M: int,
+    K: int,
+    batch_size: int,
+    input_batch_stride: int,
+    output_batch_stride: int,
+    BLOCK_SIZE_M: int,
+    BLOCK_SIZE_N: int,
+    BLOCK_SIZE_K: int,
+    num_stages: int,
+    num_warps: int,
+):
+    import tvm_ffi
+
+    from jit_kernel.triton3_5.tvm_ffi_mod import generate_tvm_ffi_source
+
+    global tvm_ffi_modules
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    key = (
+        str(A.dtype),
+        str(out.dtype),
+        M,
+        K,
+        batch_size,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        num_stages,
+        num_warps,
+    )
+
+    cache = tvm_ffi_modules["XXT"]
+    if cache is not None and key in cache:
+        module, kernel_name, gx, gy, gz = cache[key]
+    else:
+        compiled_kernel = XXT_kernel[grid](
+            A_ptr=A,
+            C_ptr=out,
+            M=M,
+            K=K,
+            a_stride_b=input_batch_stride,
+            a_stride_r=A.stride(-2),
+            a_stride_c=A.stride(-1),
+            c_stride_b=output_batch_stride,
+            c_stride_r=out.stride(-2),
+            c_stride_c=out.stride(-1),
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=8,
+            LOWER_UPPER=1,
+            num_stages=num_stages,
+            num_warps=num_warps,
+        )
+
+        cubin_bytes = compiled_kernel.kernel
+        kernel_name = compiled_kernel.name
+        sources, _constants = generate_tvm_ffi_source(compiled_kernel, kernel_name)
+        module = tvm_ffi.cpp.load_inline(
+            "triton3_5_xxt_loader",
+            cuda_sources=sources,
+            extra_ldflags=["-lcudart", "-lcuda"],
+            embed_cubin={"triton_cubin": cubin_bytes},
+        )
+
+        gx, gy, gz = int(grid[0]), 1, 1
+        if tvm_ffi_modules["XXT"] is None:
+            tvm_ffi_modules["XXT"] = {}
+        tvm_ffi_modules["XXT"][key] = (module, kernel_name, gx, gy, gz)
+
+    getattr(module, kernel_name)(
+        A,
+        out,
+        int(M),
+        int(K),
+        int(input_batch_stride),
+        int(A.stride(-2)),
+        int(A.stride(-1)),
+        int(output_batch_stride),
+        int(out.stride(-2)),
+        int(out.stride(-1)),
+        int(gx),
+        int(gy),
+        int(gz),
+    )
+    return out
+
+
+def XXT(A: torch.Tensor, out: torch.Tensor, use_tvm_ffi: Optional[bool] = None):
     """
     Launch Triton kernel to compute C = A @ A.T
     """
@@ -215,13 +1385,24 @@ def XXT(A: torch.Tensor, out: torch.Tensor):
     input_batch_stride = A.stride(0) if A.ndim == 3 else 0
     output_batch_stride = out.stride(0) if out.ndim == 3 else 0
 
-    # Hardcoded configs based on H100 autotuning
-    if K == 768:
-        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
-        num_stages, num_warps = 4, 8
-    else:
-        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
-        num_stages, num_warps = 4, 8
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, num_stages, num_warps = _xxt_config(K)
+
+    use_ffi = USE_TVM_FFI if use_tvm_ffi is None else use_tvm_ffi
+    if use_ffi:
+        return _xxt_tvm_ffi(
+            A,
+            out,
+            M,
+            K,
+            batch_size,
+            input_batch_stride,
+            output_batch_stride,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            num_stages,
+            num_warps,
+        )
 
     grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
     XXT_kernel[grid](

--- a/jit_kernel/triton3_5/tvm_ffi_mod.py
+++ b/jit_kernel/triton3_5/tvm_ffi_mod.py
@@ -1,0 +1,227 @@
+import inspect
+
+import triton
+import triton.language as tl
+
+
+def is_constexpr_param(param):
+    ann = param.annotation
+    if ann is inspect._empty:
+        return False
+    return ann is tl.constexpr or getattr(ann, "__name__", "") == "constexpr" or "constexpr" in str(ann)
+
+
+def cpp_host_type(name: str) -> str:
+    if "ptr" in name:
+        return "TensorView"
+    if "use_" in name or "is_" in name:
+        return "bool"
+    return "int32_t"
+
+
+def kernel_arg_type(name: str) -> str:
+    if "ptr" in name:
+        return "void*"
+    if "use_" in name or "is_" in name:
+        return "bool"
+    return "int32_t"
+
+
+def kernel_arg_assignment(name: str) -> str:
+    if "ptr" in name:
+        return f"kargs.{name} = {name}.data_ptr();\n"
+    return f"kargs.{name} = {name};\n"
+
+
+def runtime_arg_decl(name: str) -> str:
+    var = f"{name}_arg"
+    if "ptr" in name:
+        return f"void* {var} = {name}.data_ptr();\n"
+    if "use_" in name or "is_" in name:
+        return f"bool {var} = {name};\n"
+    return f"int32_t {var} = {name};\n"
+
+
+def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
+    """Generate a TVM-FFI CUBIN launcher for Triton 3.5 NVIDIA kernels.
+
+    Triton 3.5 appends both global_scratch and profile_scratch hidden kernel
+    arguments. This launcher currently supports the common zero-scratch case.
+    """
+    if debug:
+        print(compiled_kernel.metadata)
+        print(compiled_kernel.asm["ptx"].split(".entry", 1)[1].split(")", 1)[0])
+
+    arg_names = compiled_kernel.src.fn.arg_names
+    signature = compiled_kernel.src.fn.signature
+
+    constants = {}
+    constants_set = set()
+    for key, val in compiled_kernel.src.constants.items():
+        name = arg_names[key[0]]
+        constants[name] = (key[0], val)
+        constants_set.add(name)
+
+    if debug:
+        print("arg_names : ", arg_names)
+        print("constants : ", constants)
+
+    cpp_arg_names = []
+    launch_arg_names = []
+    for name, param in signature.parameters.items():
+        if is_constexpr_param(param):
+            continue
+
+        cpp_arg_names.append(name)
+        if name not in constants_set:
+            launch_arg_names.append(name)
+
+    cpp_params = [f"{cpp_host_type(name)} {name}" for name in cpp_arg_names]
+    cpp_params_str = ", ".join(cpp_params + ["int32_t grid_x", "int32_t grid_y", "int32_t grid_z"])
+
+    launch_args_def = [f"{kernel_arg_type(name)} {name};\n" for name in launch_arg_names]
+    launch_args = [kernel_arg_assignment(name) for name in launch_arg_names]
+
+    launch_args_def.append("CUdeviceptr global_scratch;\n")
+    launch_args.append("kargs.global_scratch = 0;\n")
+    launch_args_def.append("CUdeviceptr profile_scratch;\n")
+    launch_args.append("kargs.profile_scratch = 0;\n")
+
+    launch_args_def_str = "".join(launch_args_def)
+    launch_args_str = "".join(launch_args)
+
+    runtime_arg_decls = [runtime_arg_decl(name) for name in launch_arg_names]
+    runtime_arg_ptrs = [f"&{name}_arg" for name in launch_arg_names]
+
+    runtime_arg_decls.append("CUdeviceptr global_scratch_arg = 0;\n")
+    runtime_arg_ptrs.append("&global_scratch_arg")
+    runtime_arg_decls.append("CUdeviceptr profile_scratch_arg = 0;\n")
+    runtime_arg_ptrs.append("&profile_scratch_arg")
+
+    runtime_arg_decls_str = "".join(runtime_arg_decls)
+    runtime_arg_ptrs_str = ",\n        ".join(runtime_arg_ptrs)
+
+    if debug:
+        print(f"cpp_params_str : {cpp_params_str}")
+        print(f"launch_args_def_str : {launch_args_def_str}")
+        print(f"launch_args_str : {launch_args_str}")
+
+    META = compiled_kernel.metadata
+
+    global_scratch_size = getattr(META, "global_scratch_size", 0) or 0
+    global_scratch_align = getattr(META, "global_scratch_align", 1) or 1
+    profile_scratch_size = getattr(META, "profile_scratch_size", 0) or 0
+    profile_scratch_align = getattr(META, "profile_scratch_align", 1) or 1
+    if global_scratch_size != 0:
+        raise NotImplementedError(
+            f"Triton 3.5 TVM-FFI launcher does not allocate global scratch yet "
+            f"(size={global_scratch_size}, align={global_scratch_align})."
+        )
+    if profile_scratch_size != 0:
+        raise NotImplementedError(
+            f"Triton 3.5 TVM-FFI launcher does not allocate profile scratch yet "
+            f"(size={profile_scratch_size}, align={profile_scratch_align})."
+        )
+
+    num_warps = META.num_warps
+    shared_mem_size = META.shared
+
+    WARP_SIZE = META.target.warp_size
+
+    source = f"""
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/extra/cuda/cubin_launcher.h>
+#include <tvm/ffi/function.h>
+
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+#include <cuda_runtime.h>
+#include <cuda.h>
+
+#define USE_TVM_FFI_LAUNCH_CONVENTION 0
+
+TVM_FFI_EMBED_CUBIN(triton_cubin);
+
+namespace triton_loader {{
+using namespace tvm::ffi;
+
+struct KernelArgs {{
+    {launch_args_def_str};
+}};
+
+void {kernel_name}_launcher({cpp_params_str}) {{
+    static auto launcher = TVM_FFI_EMBED_CUBIN_GET_KERNEL(triton_cubin, "{kernel_name}");
+
+    KernelArgs kargs;
+    {launch_args_str};
+
+    {runtime_arg_decls_str}
+    void* args[] = {{
+        {runtime_arg_ptrs_str}
+    }};
+
+    cudaGetLastError();
+
+    int shared_mem_bytes = {shared_mem_size};
+    auto kernel = launcher.GetHandle();
+
+    DLDevice device = {arg_names[0]}.device();
+    auto raw_stream = TVMFFIEnvGetStream(device.device_type, device.device_id);
+
+    auto device_handle =
+        ::tvm::ffi::cuda_api::GetDeviceHandle(device.device_id);
+
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(
+        ::tvm::ffi::cuda_api::SetKernelMaxDynamicSharedMem(
+            kernel,
+            shared_mem_bytes,
+            device_handle)
+    );
+
+    tvm::ffi::dim3 grid((unsigned int)grid_x, (unsigned int)grid_y, (unsigned int)grid_z);
+    tvm::ffi::dim3 block({num_warps * WARP_SIZE}, 1, 1);
+
+#if USE_TVM_FFI_LAUNCH_CONVENTION
+    ::tvm::ffi::cuda_api::StreamHandle stream =
+        static_cast<::tvm::ffi::cuda_api::StreamHandle>(raw_stream);
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(launcher.Launch(args, grid, block, stream, shared_mem_bytes));
+#else
+#if TVM_FFI_CUBIN_LAUNCHER_USE_DRIVER_API
+    CUstream stream = static_cast<CUstream>(raw_stream);
+    size_t kargs_size = sizeof(KernelArgs);
+    void* config[] = {{
+        CU_LAUNCH_PARAM_BUFFER_POINTER, &kargs,
+        CU_LAUNCH_PARAM_BUFFER_SIZE,    &kargs_size,
+        CU_LAUNCH_PARAM_END
+    }};
+
+    CUresult result = cuLaunchKernel(
+        reinterpret_cast<CUfunction>(kernel),
+        grid.x, grid.y, grid.z,
+        block.x, block.y, block.z,
+        (unsigned int)shared_mem_bytes,
+        stream,
+        nullptr,
+        config);
+
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(result);
+#else
+    cudaStream_t stream = static_cast<cudaStream_t>(raw_stream);
+    cudaError_t result = cudaLaunchKernel(
+        reinterpret_cast<const void*>(kernel),
+        ::dim3(grid.x, grid.y, grid.z),
+        ::dim3(block.x, block.y, block.z),
+        args,
+        (size_t)shared_mem_bytes,
+        stream);
+
+    TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(result);
+#endif
+#endif
+}}
+
+}} // namespace triton_loader
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC({kernel_name}, triton_loader::{kernel_name}_launcher);
+"""
+    return source, constants


### PR DESCRIPTION
This follow-up adds a small Triton 3.5 validation layer on top of #10.

Changes:
- Add optional TVM-FFI path for the simple XXT kernel.
- Port fp8_gemm_block_scaled native baseline into triton3_5.
- Port thunder_moun_gemm native prototype into triton3_5.
- Add small standalone benchmarks for:
  - XXT native vs TVM-FFI cached launch
  - fp8_gemm_block_scaled full/symm native baseline
  - thunder_moun_gemm native prototype

Validation on H100:

Environment:
- Triton 3.5: torch 2.8.0+cu128, CUDA 12.8
- Triton 3.6 / 3.7: torch 2.11.0+cu128, CUDA 12.8
- GPU: NVIDIA H100 PCIe, capability (9, 0)

Smoke benchmarks:
- XXT works on Triton 3.5 / 3.6 / 3.7.
- TVM-FFI cached path writes output correctly; sentinel cached_remaining=0.
- Native and TVM-FFI timings are nearly identical for XXT.

Standalone fp8_gemm_block_scaled benchmarks:
- fp8_gemm_block_scaled full/symm native baselines work on Triton 3.5 / 3.6 / 3.7.
- Newer Triton environments improve fp8_gemm_block_scaled:
  - full M=4096: 3.5 0.613 ms, 3.6 0.512 ms, 3.7 0.506 ms
  - symm M=4096: 3.5 0.318 ms, 3.6 0.291 ms, 3.7 0.293 ms

Original benchmark/moun/bench_symm_gemm.py with triton3_5 kernels:
- V1/full M=4096: 3.5 0.628 ms, 3.6 0.516 ms, 3.7 0.512 ms
- V3/symm M=4096: 3.5 0.336 ms, 3.6 0.303 ms, 3.7 0.308 ms
- ThunderMoun M=4096: 3.5 17.122 ms, 3.6 20.020 ms, 3.7 20.223 ms

Benchmarks result in triton3_5
[triton35_validation_logs.tar.gz](https://github.com/user-attachments/files/29988520/triton35_validation_logs.tar.gz)

Original benchmark/moun/bench_symm_gemm.py results:
[triton35_original_benchmark_logs.tar.gz](https://github.com/user-attachments/files/29988941/triton35_original_benchmark_logs.tar.gz)
