### PR TITLE
Add CUDA profiling for ThunderMoun symmetric GEMM

### DIFF
--- a/jit_kernel/csrc/thunder_moun/bench_symm_gemm_cuda.py
+++ b/jit_kernel/csrc/thunder_moun/bench_symm_gemm_cuda.py
@@ -1,0 +1,616 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from jit_kernel.thunder_moun import (  # noqa: E402
+    CUDA_PROFILER_HEADER_U64_WORDS,
+    CUDA_PROFILER_RECORD_U64_WORDS,
+    allocate_cuda_profiler_buffer,
+    estimate_cuda_profiler_records,
+    symm_gemm_block_scaled,
+)
+
+
+SEED = 42
+BLOCK_SIZE = 128
+
+EVENT_KIND_INSTANT = 0
+EVENT_KIND_BEGIN = 1
+EVENT_KIND_END = 2
+
+EVENT_NAMES = {
+    1: "kernel_enter",
+    2: "pipeline_enter",
+    10: "task",
+    11: "task_map",
+    20: "prefetch_tma",
+    21: "scale_x_load",
+    22: "scale_w_load",
+    30: "tma_wait",
+    31: "mma_issue",
+    32: "producer_load_once",
+    33: "wgmma_wait",
+    34: "scale_apply_accum",
+    40: "epilogue_smem_store",
+    41: "splitk_reduce",
+    42: "store_lower",
+    43: "mirror_transpose",
+    44: "mirror_store",
+    50: "task_done",
+}
+
+
+def ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def make_inputs(m: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(SEED)
+
+    x = torch.randn(m, m, dtype=torch.bfloat16, device="cuda")
+    xs_lhs = torch.ones(
+        (m, ceil_div(m, BLOCK_SIZE)), dtype=torch.float32, device="cuda"
+    )
+    xs_rhs = torch.ones(
+        (ceil_div(m, BLOCK_SIZE), ceil_div(m, BLOCK_SIZE)),
+        dtype=torch.float32,
+        device="cuda",
+    )
+
+    xq = x
+    wq = x
+    x_fp8 = xq.to(torch.float8_e4m3fn)
+    w_fp8 = wq.to(torch.float8_e4m3fn)
+    return x_fp8, w_fp8, xs_lhs, xs_rhs
+
+
+def time_cuda_path(
+    fn: Callable[[], Any],
+    warmup: int,
+    iters: int,
+) -> Tuple[float, float, Any]:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    last_result = None
+    for _ in range(iters):
+        last_result = fn()
+    end_event.record()
+    torch.cuda.synchronize()
+
+    host_ms = (time.time() - start) / iters * 1000
+    device_ms = start_event.elapsed_time(end_event) / iters
+    return host_ms, device_ms, last_result
+
+
+def _u32_lo(value: int) -> int:
+    return value & 0xFFFFFFFF
+
+
+def _u32_hi(value: int) -> int:
+    return (value >> 32) & 0xFFFFFFFF
+
+
+def _u16_lo(value: int) -> int:
+    return value & 0xFFFF
+
+
+def _u16_hi(value: int) -> int:
+    return (value >> 16) & 0xFFFF
+
+
+def decode_profiler_records(
+    profiler_buffer: torch.Tensor,
+) -> Tuple[Dict[str, Any], List[Dict[str, int]]]:
+    words = [int(v) for v in profiler_buffer.detach().cpu().tolist()]
+    if len(words) < CUDA_PROFILER_HEADER_U64_WORDS:
+        raise ValueError("profiler buffer is smaller than the profiler header")
+
+    header_word0 = words[0]
+    header_word1 = words[1]
+    header_word2 = words[2]
+    header_word3 = words[3]
+    grid_xy = _u32_hi(header_word0)
+    grid_x = _u16_lo(grid_xy)
+    grid_y = _u16_hi(grid_xy)
+    header = {
+        "capacity": _u32_lo(header_word0),
+        "grid_x": grid_x,
+        "grid_y": grid_y,
+        "num_ctas": grid_x * grid_y,
+        "records_per_cta": _u32_lo(header_word1),
+        "records_per_task": _u32_hi(header_word1),
+        "max_tasks_per_cta": _u32_lo(header_word2),
+        "max_k_tiles_per_task": _u32_hi(header_word2),
+        "cta_slots": _u32_lo(header_word3),
+        "per_k_slots": _u32_hi(header_word3),
+    }
+    header["required_capacity"] = header["num_ctas"] * header["records_per_cta"]
+    header["static_slots"] = (
+        header["records_per_task"]
+        - header["max_k_tiles_per_task"] * header["per_k_slots"]
+    )
+
+    record_count = min(header["capacity"], header["required_capacity"])
+    record_offset = CUDA_PROFILER_HEADER_U64_WORDS
+    record_words = words[
+        record_offset : record_offset + record_count * CUDA_PROFILER_RECORD_U64_WORDS
+    ]
+
+    records = []
+    empty_slots = 0
+    for slot_idx in range(record_count):
+        i = slot_idx * CUDA_PROFILER_RECORD_U64_WORDS
+        word0, word1 = record_words[i : i + CUDA_PROFILER_RECORD_U64_WORDS]
+        if word0 == 0 and word1 == 0:
+            empty_slots += 1
+            continue
+
+        payload = _u32_lo(word1)
+        tag = (word1 >> 32) & 0xFFFF
+        smid = (word1 >> 48) & 0xFFFF
+        event_id = tag & 0xFF
+        if event_id == 0:
+            empty_slots += 1
+            continue
+
+        kind = (tag >> 8) & 0x3
+        flags = (tag >> 10) & 0x3F
+        cta_id = slot_idx // header["records_per_cta"]
+        slot_in_cta = slot_idx % header["records_per_cta"]
+        block_x = cta_id % header["grid_x"] if header["grid_x"] else 0
+        block_y = (cta_id // header["grid_x"]) if header["grid_x"] else 0
+        task_iter = -1
+        k_iter = -1
+        slot_scope = "cta"
+        event_slot = slot_in_cta
+
+        if slot_in_cta >= header["cta_slots"]:
+            slot_scope = "task"
+            task_region = slot_in_cta - header["cta_slots"]
+            task_iter = task_region // header["records_per_task"]
+            slot_in_task = task_region % header["records_per_task"]
+            event_slot = slot_in_task
+            if slot_in_task >= header["static_slots"]:
+                slot_scope = "k"
+                k_region = slot_in_task - header["static_slots"]
+                k_iter = k_region // header["per_k_slots"]
+                event_slot = k_region % header["per_k_slots"]
+
+        records.append(
+            {
+                "timestamp": word0,
+                "event_id": event_id,
+                "kind": kind,
+                "flags": flags,
+                "cta_id": cta_id,
+                "block_x": block_x,
+                "block_y": block_y,
+                "task_iter": task_iter,
+                "task_id": (
+                    block_y + task_iter * header["grid_y"]
+                    if task_iter >= 0
+                    else -1
+                ),
+                "k_iter": k_iter,
+                "slot_scope": slot_scope,
+                "event_slot": event_slot,
+                "thread_id": 0,
+                "sm_id": smid,
+                "payload": payload,
+            }
+        )
+
+    header["slots_scanned"] = record_count
+    header["empty_slots"] = empty_slots
+    header["unused_capacity"] = max(0, header["capacity"] - record_count)
+    return header, records
+
+
+def _duration_stats(durations: List[int]) -> Dict[str, float]:
+    if not durations:
+        return {
+            "count": 0,
+            "total_us": 0.0,
+            "mean_us": 0.0,
+            "p50_us": 0.0,
+            "p90_us": 0.0,
+            "p99_us": 0.0,
+            "max_us": 0.0,
+        }
+
+    sorted_values = sorted(durations)
+
+    def percentile(q: float) -> float:
+        idx = min(len(sorted_values) - 1, int(round((len(sorted_values) - 1) * q)))
+        return sorted_values[idx] / 1000.0
+
+    total = sum(sorted_values)
+    return {
+        "count": len(sorted_values),
+        "total_us": total / 1000.0,
+        "mean_us": (total / len(sorted_values)) / 1000.0,
+        "p50_us": percentile(0.50),
+        "p90_us": percentile(0.90),
+        "p99_us": percentile(0.99),
+        "max_us": sorted_values[-1] / 1000.0,
+    }
+
+
+def build_profiler_report(profiler_buffer: torch.Tensor) -> Dict[str, Any]:
+    header, records = decode_profiler_records(profiler_buffer)
+
+    open_events = defaultdict(list)
+    durations_by_event = defaultdict(list)
+    instant_counts = defaultdict(int)
+    unmatched_end = defaultdict(int)
+
+    for record in records:
+        event_id = record["event_id"]
+        key = (
+            event_id,
+            record["cta_id"],
+            record["task_iter"],
+            record["k_iter"],
+            record["sm_id"],
+        )
+
+        if record["kind"] == EVENT_KIND_BEGIN:
+            open_events[key].append(record)
+        elif record["kind"] == EVENT_KIND_END:
+            if open_events[key]:
+                begin = open_events[key].pop()
+                duration = max(0, record["timestamp"] - begin["timestamp"])
+                durations_by_event[event_id].append(duration)
+            else:
+                unmatched_end[event_id] += 1
+        elif record["kind"] == EVENT_KIND_INSTANT:
+            instant_counts[event_id] += 1
+
+    unmatched_begin = defaultdict(int)
+    for key, stack in open_events.items():
+        if stack:
+            unmatched_begin[key[0]] += len(stack)
+
+    event_summaries = {}
+    for event_id, durations in sorted(durations_by_event.items()):
+        event_summaries[EVENT_NAMES.get(event_id, f"event_{event_id}")] = (
+            _duration_stats(durations)
+        )
+
+    return {
+        "header": header,
+        "records": {
+            "parsed": len(records),
+            "slots_scanned": header["slots_scanned"],
+            "capacity": header["capacity"],
+            "required": header["required_capacity"],
+            "empty_slots": header["empty_slots"],
+            "unused_capacity": header["unused_capacity"],
+            "truncated": header["capacity"] < header["required_capacity"],
+        },
+        "events": event_summaries,
+        "instant_counts": {
+            EVENT_NAMES.get(event_id, f"event_{event_id}"): count
+            for event_id, count in sorted(instant_counts.items())
+        },
+        "unmatched_begin": {
+            EVENT_NAMES.get(event_id, f"event_{event_id}"): count
+            for event_id, count in sorted(unmatched_begin.items())
+        },
+        "unmatched_end": {
+            EVENT_NAMES.get(event_id, f"event_{event_id}"): count
+            for event_id, count in sorted(unmatched_end.items())
+        },
+    }
+
+
+def _record_label(record: Dict[str, int]) -> str:
+    if record["slot_scope"] == "k":
+        return (
+            f"cta={record['cta_id']} task={record['task_iter']} "
+            f"k={record['k_iter']} sm={record['sm_id']}"
+        )
+    if record["slot_scope"] == "task":
+        return f"cta={record['cta_id']} task={record['task_iter']} sm={record['sm_id']}"
+    return f"cta={record['cta_id']} sm={record['sm_id']}"
+
+
+def _trace_thread_id(record: Dict[str, int], lane_mode: str) -> str:
+    if lane_mode == "cta":
+        return f"cta{record['cta_id']}"
+    if record["task_iter"] >= 0:
+        return f"cta{record['cta_id']}:task{record['task_iter']}"
+    return f"cta{record['cta_id']}:meta"
+
+
+def _cta_trace_path(trace_path: Path) -> Path:
+    return trace_path.with_name(f"{trace_path.stem}_by_cta{trace_path.suffix}")
+
+
+def export_chrome_trace(
+    profiler_buffer: torch.Tensor,
+    trace_path: Path,
+    lane_mode: str = "task",
+) -> Dict[str, int]:
+    if lane_mode not in {"task", "cta"}:
+        raise ValueError(f"Unsupported trace lane mode: {lane_mode}")
+
+    _header, records = decode_profiler_records(profiler_buffer)
+    metadata = {
+        "source": "ThunderMoun CUDA embedded profiler",
+        "lane_mode": lane_mode,
+    }
+    if not records:
+        trace = {
+            "traceEvents": [],
+            "displayTimeUnit": "ns",
+            "metadata": metadata,
+        }
+        trace_path.parent.mkdir(parents=True, exist_ok=True)
+        trace_path.write_text(json.dumps(trace, indent=2), encoding="utf-8")
+        return {"events": 0, "duration_events": 0, "instant_events": 0}
+
+    base_ts = min(record["timestamp"] for record in records)
+    pid = f"ThunderMoun CUDA ({lane_mode} lanes)"
+    trace_events = []
+    open_events = defaultdict(list)
+    instant_events = 0
+    duration_events = 0
+
+    for record in sorted(records, key=lambda item: item["timestamp"]):
+        event_id = record["event_id"]
+        name = EVENT_NAMES.get(event_id, f"event_{event_id}")
+        tid = _trace_thread_id(record, lane_mode)
+        ts_us = (record["timestamp"] - base_ts) / 1000.0
+        args = {
+            "cta_id": record["cta_id"],
+            "block_x": record["block_x"],
+            "block_y": record["block_y"],
+            "task_iter": record["task_iter"],
+            "task_id": record["task_id"],
+            "k_iter": record["k_iter"],
+            "sm_id": record["sm_id"],
+            "payload": record["payload"],
+            "scope": record["slot_scope"],
+            "slot": record["event_slot"],
+        }
+
+        key = (
+            event_id,
+            record["cta_id"],
+            record["task_iter"],
+            record["k_iter"],
+            record["sm_id"],
+        )
+        if record["kind"] == EVENT_KIND_BEGIN:
+            open_events[key].append(record)
+        elif record["kind"] == EVENT_KIND_END:
+            if not open_events[key]:
+                continue
+            begin = open_events[key].pop()
+            begin_ts_us = (begin["timestamp"] - base_ts) / 1000.0
+            dur_us = max(0.0, (record["timestamp"] - begin["timestamp"]) / 1000.0)
+            args["begin_payload"] = begin["payload"]
+            args["end_payload"] = record["payload"]
+            trace_events.append(
+                {
+                    "name": name,
+                    "cat": record["slot_scope"],
+                    "ph": "X",
+                    "ts": begin_ts_us,
+                    "dur": dur_us,
+                    "pid": pid,
+                    "tid": tid,
+                    "args": args,
+                }
+            )
+            duration_events += 1
+        elif record["kind"] == EVENT_KIND_INSTANT:
+            trace_events.append(
+                {
+                    "name": name,
+                    "cat": record["slot_scope"],
+                    "ph": "i",
+                    "s": "t",
+                    "ts": ts_us,
+                    "pid": pid,
+                    "tid": tid,
+                    "args": args,
+                }
+            )
+            instant_events += 1
+
+    trace_events.sort(key=lambda item: (item["ts"], str(item["tid"]), item["name"]))
+    trace = {
+        "traceEvents": trace_events,
+        "displayTimeUnit": "ns",
+        "metadata": metadata,
+    }
+    trace_path.parent.mkdir(parents=True, exist_ok=True)
+    trace_path.write_text(json.dumps(trace, indent=2), encoding="utf-8")
+    return {
+        "events": len(trace_events),
+        "duration_events": duration_events,
+        "instant_events": instant_events,
+    }
+
+
+def print_profiler_report(report: Dict[str, Any], top_k: int = 20) -> None:
+    records = report["records"]
+    print("\nProfiler records:")
+    print(
+        f"  parsed={records['parsed']} slots_scanned={records['slots_scanned']} "
+        f"capacity={records['capacity']} required={records['required']} "
+        f"empty={records['empty_slots']} truncated={records['truncated']}"
+    )
+
+    if report["instant_counts"]:
+        print("  instant events:")
+        for name, count in report["instant_counts"].items():
+            print(f"    {name:<24} {count}")
+
+    rows = sorted(
+        report["events"].items(),
+        key=lambda item: item[1]["total_us"],
+        reverse=True,
+    )
+    print("\nProfiler summary (globaltimer ticks treated as ns):")
+    print(
+        "  "
+        + f"{'event':<24} {'count':>8} {'total_us':>12} {'mean_us':>10} "
+        + f"{'p50_us':>10} {'p90_us':>10} {'p99_us':>10} {'max_us':>10}"
+    )
+    for name, stats in rows[:top_k]:
+        print(
+            "  "
+            + f"{name:<24} {stats['count']:>8} {stats['total_us']:>12.3f} "
+            + f"{stats['mean_us']:>10.3f} {stats['p50_us']:>10.3f} "
+            + f"{stats['p90_us']:>10.3f} {stats['p99_us']:>10.3f} "
+            + f"{stats['max_us']:>10.3f}"
+        )
+
+    if report["unmatched_begin"] or report["unmatched_end"]:
+        print("\nProfiler pairing warnings:")
+        for name, count in report["unmatched_begin"].items():
+            print(f"  unmatched begin {name}: {count}")
+        for name, count in report["unmatched_end"].items():
+            print(f"  unmatched end   {name}: {count}")
+
+
+def bench_cuda_symm_gemm(
+    m: int = 4096,
+    warmup: int = 25,
+    iters: int = 100,
+    max_profiler_records: Optional[int] = None,
+    trace_json: Optional[Path] = None,
+) -> Dict[str, Any]:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark")
+
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    x_fp8, w_fp8, xs_lhs, xs_rhs = make_inputs(m)
+    profiler_capacity = estimate_cuda_profiler_records(m, m, m)
+    if max_profiler_records is not None:
+        profiler_capacity = min(profiler_capacity, max_profiler_records)
+    profiler_buffer = allocate_cuda_profiler_buffer(profiler_capacity, x_fp8.device)
+
+    baseline_fn = lambda: symm_gemm_block_scaled(x_fp8, w_fp8, xs_lhs, xs_rhs)
+    profile_fn = lambda: symm_gemm_block_scaled(
+        x_fp8,
+        w_fp8,
+        xs_lhs,
+        xs_rhs,
+        enable_cuda_profiler=True,
+        profiler_buffer=profiler_buffer,
+    )
+
+    baseline_host_ms, baseline_device_ms, _ = time_cuda_path(
+        baseline_fn, warmup, iters
+    )
+    profile_host_ms, profile_device_ms, _ = time_cuda_path(profile_fn, warmup, iters)
+
+    report = build_profiler_report(profiler_buffer)
+    report["timing"] = {
+        "baseline_host_ms": baseline_host_ms,
+        "baseline_device_ms": baseline_device_ms,
+        "profile_host_ms": profile_host_ms,
+        "profile_device_ms": profile_device_ms,
+        "profile_device_overhead_ms": profile_device_ms - baseline_device_ms,
+        "profile_device_overhead_pct": (
+            (profile_device_ms / baseline_device_ms - 1.0) * 100.0
+            if baseline_device_ms > 0
+            else 0.0
+        ),
+    }
+
+    print(f"\nCUDA ThunderMoun Symm GEMM: M=N=K={m}")
+    print(f"warmup={warmup}, iters={iters}")
+    print(
+        f"Cuda Muon Symm Gemm          : {baseline_host_ms:.3f} ms, "
+        f"device {baseline_device_ms:.3f} ms"
+    )
+    print(
+        f"Cuda Muon Symm Gemm Profiled : {profile_host_ms:.3f} ms, "
+        f"device {profile_device_ms:.3f} ms"
+    )
+    print(
+        "Profiler overhead            : "
+        f"{report['timing']['profile_device_overhead_ms']:.3f} ms, "
+        f"{report['timing']['profile_device_overhead_pct']:.2f}% device"
+    )
+    print_profiler_report(report)
+    if trace_json is not None:
+        trace_stats = export_chrome_trace(profiler_buffer, trace_json, lane_mode="task")
+        cta_trace_json = _cta_trace_path(trace_json)
+        cta_trace_stats = export_chrome_trace(
+            profiler_buffer, cta_trace_json, lane_mode="cta"
+        )
+        report["trace"] = {
+            "path": str(trace_json),
+            **trace_stats,
+        }
+        report["trace_by_cta"] = {
+            "path": str(cta_trace_json),
+            **cta_trace_stats,
+        }
+        print(
+            "\nChrome trace: "
+            f"{trace_json} "
+            f"({trace_stats['duration_events']} durations, "
+            f"{trace_stats['instant_events']} instants)"
+        )
+        print(
+            "Chrome trace by CTA: "
+            f"{cta_trace_json} "
+            f"({cta_trace_stats['duration_events']} durations, "
+            f"{cta_trace_stats['instant_events']} instants)"
+        )
+
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark ThunderMoun CUDA path.")
+    parser.add_argument("--m", type=int, default=4096)
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--max-profiler-records", type=int, default=None)
+    parser.add_argument(
+        "--trace-json",
+        type=Path,
+        default=None,
+        help="Write Chrome Trace JSON for chrome://tracing or Perfetto.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    bench_cuda_symm_gemm(
+        m=args.m,
+        warmup=args.warmup,
+        iters=args.iters,
+        max_profiler_records=args.max_profiler_records,
+        trace_json=args.trace_json,
+    )

--- a/jit_kernel/csrc/thunder_moun/block/nv_block_gemm_scaled_impl.h
+++ b/jit_kernel/csrc/thunder_moun/block/nv_block_gemm_scaled_impl.h
@@ -14,6 +14,7 @@ namespace cg = cooperative_groups;
 #include "../arch/cluster/cluster.h"
 
 #include "../arch/warpgroup/reg_allocator.h"
+#include "../profiler.cuh"
 
 // TODO (yiakwy) : refactor flashFloat FragView with Shape and Layout component with support of device side Flash Float datatype
 
@@ -59,6 +60,7 @@ struct HopperPersistentSplitKPipeline {
         int num_blocks_m,
         int num_blocks_n,
         uint8_t* smem_buffer
+        FFJK_PROFILER_KERNEL_PARAMS
     ) {
         using fp8_t = __nv_fp8_e4m3;
         using fp32_t = float;
@@ -138,6 +140,16 @@ struct HopperPersistentSplitKPipeline {
 
         int k_tiles_per_slice = (k_tiles_total + split_k - 1) / split_k;
 
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+        FFJK_PROFILER_DEFINE_LAYOUT(total_symmetric_tiles, k_tiles_per_slice);
+        int ffjk_prof_task_iter = 0;
+        int ffjk_prof_k_iter = -1;
+        FFJK_PROF_CTA_EVENT_PAYLOAD(
+            ffjk::kProfilerEventPipelineEnter,
+            K,
+            total_symmetric_tiles);
+#endif
+
         int k_start = split_k_id * k_tiles_per_slice;
         int k_end = min(k_tiles_total, (split_k_id + 1) * k_tiles_per_slice);
 
@@ -148,6 +160,15 @@ struct HopperPersistentSplitKPipeline {
         __syncthreads();
 
         while (local_task_id < total_symmetric_tiles) {
+            const int task_id = local_task_id;
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+            ffjk_prof_k_iter = -1;
+#endif
+            FFJK_PROF_BEGIN(
+                ffjk::kProfilerEventTask,
+                task_id,
+                ffjk::cuda_profiler_pack_u16(blockIdx.x, blockIdx.y));
+
             accum.clear();
 
             // if (threadIdx.x == 0 && blockIdx.x == 0) {
@@ -205,6 +226,11 @@ struct HopperPersistentSplitKPipeline {
                 }
             }
 
+            FFJK_PROF_EVENT_PAYLOAD(
+                ffjk::kProfilerEventTaskMap,
+                task_id,
+                ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
+
             // if (threadIdx.x == 0 && blockIdx.x == 0) {
             //     printf("[after] [Split#%d] [SM#%d] block#(%d, %d) initiate TAM loading ...\n", blockIdx.x, blockIdx.y, block_idx_m, block_idx_n);
             // }
@@ -214,6 +240,10 @@ struct HopperPersistentSplitKPipeline {
 
             // 1. Ramp Up Fill : to initiate the pipeline, we will fill STAGES-1 stages of data before entering the main loop, and then maintain 1 stage ahead of the main loop to keep the pipeline full.
 
+            FFJK_PROF_BEGIN(
+                ffjk::kProfilerEventPrefetchTma,
+                task_id,
+                ffjk::cuda_profiler_pack_u16(k_start, k_end));
 #if  USE_CLUSTER_MULTICAST
             producer<STAGES, GROUP_SIZE_M, BM, BN, BK, USE_CLUSTER_MULTICAST, USE_LINEAR_TO_TRIL_LAYOUT>::load(
                 tid, group_id, block_idx_m, block_idx_n,
@@ -231,6 +261,10 @@ struct HopperPersistentSplitKPipeline {
                 cache_hint_lhs, cache_hint_rhs,
                 write_stage/*src & dst*/);
 #endif
+            FFJK_PROF_END(
+                ffjk::kProfilerEventPrefetchTma,
+                task_id,
+                ffjk::cuda_profiler_pack_u16(k_start, k_end));
 
             // if (threadIdx.x == 0 && blockIdx.x == 0) {
             //     printf("[Prefetch] [Split#%d] [SM#%d] block#(%d, %d) enter into main loop ...\n", blockIdx.x, blockIdx.y, block_idx_m, block_idx_n);
@@ -251,6 +285,10 @@ struct HopperPersistentSplitKPipeline {
             // NOTE (yiakwy) : prefetch all scale without TMA
 
             // TODO (yiakwy) : remap shmem_XS to per-thread registers to reduce the latency, since the scale load is on the critical path of the main loop.
+            FFJK_PROF_BEGIN(
+                ffjk::kProfilerEventScaleXLoad,
+                task_id,
+                total_xs_elements);
             #pragma unroll 4
             for (int i = tid; i < total_xs_elements; i += threads_per_block) {
                 int s_row = i / k_tiles;
@@ -262,8 +300,16 @@ struct HopperPersistentSplitKPipeline {
                 shmem_XS[s_col * BM + s_row] = scale_X[g_row * stride_xs_m + g_col];
             }
             __syncthreads();
+            FFJK_PROF_END(
+                ffjk::kProfilerEventScaleXLoad,
+                task_id,
+                total_xs_elements);
 
            // TODO (yiakwy) : remap shmem_WS to per-thread registers to reduce the latency, since the scale load is on the critical path of the main loop.
+            FFJK_PROF_BEGIN(
+                ffjk::kProfilerEventScaleWLoad,
+                task_id,
+                total_ws_elements);
             #pragma unroll 4
             for (int i = tid; i < total_ws_elements; i += threads_per_block) {
                 int s_col = i;
@@ -274,11 +320,18 @@ struct HopperPersistentSplitKPipeline {
                 shmem_WS[s_col] = scale_W[g_row * stride_ws_n + g_col];
             }
             __syncthreads();
+            FFJK_PROF_END(
+                ffjk::kProfilerEventScaleWLoad,
+                task_id,
+                total_ws_elements);
 
             int tma_phase = 0;
 
             // 2. main loop
             for (int k_tile = k_start; k_tile < k_end; ++k_tile) {
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+                ffjk_prof_k_iter = k_tile - k_start;
+#endif
                 uint32_t current_barrier = __cvta_generic_to_shared(&barriers[read_stage]);
 
                 // if (threadIdx.x == 0 && blockIdx.x == 0) {
@@ -287,7 +340,15 @@ struct HopperPersistentSplitKPipeline {
 
                 if (threadIdx.x == 0) {
                     // NOTE (yiakwy) : wait parity switch from phase (1 at prfetch stage 0) to ^phase (0 when TMA finish stage 0 transactions)
+                    FFJK_PROF_BEGIN(
+                        ffjk::kProfilerEventTmaWait,
+                        task_id,
+                        ffjk::cuda_profiler_pack_u16(k_tile, read_stage));
                     nvgpu::arch::tma_wait(current_barrier, tma_phase);
+                    FFJK_PROF_END(
+                        ffjk::kProfilerEventTmaWait,
+                        task_id,
+                        ffjk::cuda_profiler_pack_u16(k_tile, read_stage));
                 }
                 __syncthreads();
 
@@ -303,11 +364,23 @@ struct HopperPersistentSplitKPipeline {
                 uint32_t active_smem_w = __cvta_generic_to_shared(&shmem_W[read_stage]);
 
                 // NOTE (yiakwy) : hopper (SM90a) does not support mma_scaled instruction, sx, sw will be ignored in the current implementation, and the scaling will be applied in the epilogue.
+                FFJK_PROF_BEGIN(
+                    ffjk::kProfilerEventMmaIssue,
+                    task_id,
+                    ffjk::cuda_profiler_pack_u16(k_tile, read_stage));
                 HopperWGMMAExecutor::mma_scaled(local_step_accum, active_smem_x, active_smem_w);
+                FFJK_PROF_END(
+                    ffjk::kProfilerEventMmaIssue,
+                    task_id,
+                    ffjk::cuda_profiler_pack_u16(k_tile, read_stage));
 
                 int next_k = k_tile + (STAGES - 1);
                 if (next_k < k_end) {
 
+                    FFJK_PROF_BEGIN(
+                        ffjk::kProfilerEventProducerLoadOnce,
+                        task_id,
+                        ffjk::cuda_profiler_pack_u16(next_k, write_stage));
 #if  USE_CLUSTER_MULTICAST
                     producer<STAGES, GROUP_SIZE_M, BM, BN, BK, USE_CLUSTER_MULTICAST, USE_LINEAR_TO_TRIL_LAYOUT>::load_once(
                         tid, group_id,
@@ -325,13 +398,33 @@ struct HopperPersistentSplitKPipeline {
                         cache_hint_lhs, cache_hint_rhs, write_stage, tma_phase
                     );
 #endif
+                    FFJK_PROF_END(
+                        ffjk::kProfilerEventProducerLoadOnce,
+                        task_id,
+                        ffjk::cuda_profiler_pack_u16(next_k, write_stage));
 
                 } // next_k < k_end
 
+                FFJK_PROF_BEGIN(
+                    ffjk::kProfilerEventWgmmaWait,
+                    task_id,
+                    ffjk::cuda_profiler_pack_u16(k_tile, read_stage));
                 HopperWGMMAExecutor::commit_and_wait();
+                FFJK_PROF_END(
+                    ffjk::kProfilerEventWgmmaWait,
+                    task_id,
+                    ffjk::cuda_profiler_pack_u16(k_tile, read_stage));
 
+                FFJK_PROF_BEGIN(
+                    ffjk::kProfilerEventScaleApplyAccum,
+                    task_id,
+                    k_tile);
                 local_step_accum.mul_(&shmem_XS[0], &shmem_WS[0], k_tile - k_start);
                 accum.add_(local_step_accum);
+                FFJK_PROF_END(
+                    ffjk::kProfilerEventScaleApplyAccum,
+                    task_id,
+                    k_tile);
                 __syncwarp();
 
                 read_stage = (read_stage + 1) % STAGES;
@@ -343,8 +436,16 @@ struct HopperPersistentSplitKPipeline {
             // 3. Epilogue
             //   - first write data back to share memory for SPLIT-K reduction via NoC
             //   - applying successive operations upon tile results in the epilogue, such as bias add, activation, etc, can be fused in this step to save memory bandwidth.
+            FFJK_PROF_BEGIN(
+                ffjk::kProfilerEventEpilogueSmemStore,
+                task_id,
+                ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
             accum.store(shmem_epilogue);
             __syncthreads();
+            FFJK_PROF_END(
+                ffjk::kProfilerEventEpilogueSmemStore,
+                task_id,
+                ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
 
             // if (threadIdx.x == 0 && blockIdx.x == 1) {
             //     printf("[Epilogue] [Split#%d] [SM#%d] write block <%d, %d> back to shared memory...\n", blockIdx.x, blockIdx.y, block_idx_m, block_idx_n);
@@ -360,6 +461,10 @@ struct HopperPersistentSplitKPipeline {
             auto cluster = cooperative_groups::this_cluster();
             cluster.sync();
 
+            FFJK_PROF_BEGIN(
+                ffjk::kProfilerEventSplitKReduce,
+                task_id,
+                split_k);
             if (split_k > 1) {
                 if (split_k_id == 0) {
                     if (threadIdx.x == 0) {
@@ -380,9 +485,17 @@ struct HopperPersistentSplitKPipeline {
             } //  split_k > 1
 
             __syncthreads();
+            FFJK_PROF_END(
+                ffjk::kProfilerEventSplitKReduce,
+                task_id,
+                split_k);
 
             if (split_k_id == 0) {
                 if (threadIdx.x == 0) {
+                    FFJK_PROF_BEGIN(
+                        ffjk::kProfilerEventStoreLower,
+                        task_id,
+                        ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
                     uint64_t tma_o_addr = reinterpret_cast<uint64_t>(tma_desc_O);
                     uint32_t smem_epilogue_addr  = static_cast<uint32_t>(__cvta_generic_to_shared(&shmem_epilogue[0]));
 
@@ -394,6 +507,10 @@ struct HopperPersistentSplitKPipeline {
                         "r"(block_idx_n * BN), "r"(block_idx_m * BM)
                         : "memory"
                     );
+                    FFJK_PROF_END(
+                        ffjk::kProfilerEventStoreLower,
+                        task_id,
+                        ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
                 }
 
 #if (defined(USE_LINEAR_TO_TRIL_LAYOUT)) && USE_LINEAR_TO_TRIL_LAYOUT
@@ -407,7 +524,15 @@ struct HopperPersistentSplitKPipeline {
                     __syncthreads();
 
                     // NOTE (yiakwy) : inplace transpose
+                    FFJK_PROF_BEGIN(
+                        ffjk::kProfilerEventMirrorTranspose,
+                        task_id,
+                        ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
                     frag_view._transpose();
+                    FFJK_PROF_END(
+                        ffjk::kProfilerEventMirrorTranspose,
+                        task_id,
+                        ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
 #else
                     // NOTE (yiakwy) : outplace transpose
                     // TODO (yiakwy) : outplace transpose
@@ -416,6 +541,10 @@ struct HopperPersistentSplitKPipeline {
 #endif // USE_INPALCE_TRI_TRANSPOSE
 
                     if (threadIdx.x == 0) {
+                        FFJK_PROF_BEGIN(
+                            ffjk::kProfilerEventMirrorStore,
+                            task_id,
+                            ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
 #if SWIZZLE_64B_STORE
                         uint64_t tma_o_addr = reinterpret_cast<uint64_t>(tma_desc_O_swizzle);
 #else
@@ -453,6 +582,10 @@ struct HopperPersistentSplitKPipeline {
                             : "memory"
                         );
 #endif // SWIZZLE_64B_STORE
+                        FFJK_PROF_END(
+                            ffjk::kProfilerEventMirrorStore,
+                            task_id,
+                            ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
                     }
 
                     asm volatile("fence.proxy.async.shared::cta;\n" ::: "memory");
@@ -504,6 +637,18 @@ struct HopperPersistentSplitKPipeline {
                 local_task_id += gridDim.y;
             }
             __syncthreads();
+
+            FFJK_PROF_END(
+                ffjk::kProfilerEventTask,
+                task_id,
+                ffjk::cuda_profiler_pack_u16(block_idx_m, block_idx_n));
+            FFJK_PROF_EVENT_PAYLOAD(
+                ffjk::kProfilerEventTaskDone,
+                task_id,
+                local_task_id);
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+            ++ffjk_prof_task_iter;
+#endif
 
         } // while
     }

--- a/jit_kernel/csrc/thunder_moun/check_symm_gemm_cuda_correctness.py
+++ b/jit_kernel/csrc/thunder_moun/check_symm_gemm_cuda_correctness.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import torch
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from jit_kernel.thunder_moun import (  # noqa: E402
+    allocate_cuda_profiler_buffer,
+    estimate_cuda_profiler_records,
+    symm_gemm_block_scaled,
+)
+
+
+SEED = 42
+BLOCK_SIZE = 128
+
+
+def ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def make_inputs(m: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(SEED)
+    x = torch.randn(m, m, dtype=torch.bfloat16, device="cuda")
+    xs_lhs = torch.ones(
+        (m, ceil_div(m, BLOCK_SIZE)), dtype=torch.float32, device="cuda"
+    )
+    xs_rhs = torch.ones(
+        (ceil_div(m, BLOCK_SIZE), ceil_div(m, BLOCK_SIZE)),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    x_fp8 = x.to(torch.float8_e4m3fn)
+    w_fp8 = x.to(torch.float8_e4m3fn)
+    return x_fp8, w_fp8, xs_lhs, xs_rhs
+
+
+def clone_result(result):
+    if isinstance(result, tuple):
+        result = result[0]
+    torch.cuda.synchronize()
+    return result.detach().clone()
+
+
+def run_baseline(
+    x_fp8: torch.Tensor,
+    w_fp8: torch.Tensor,
+    xs_lhs: torch.Tensor,
+    xs_rhs: torch.Tensor,
+) -> torch.Tensor:
+    return clone_result(symm_gemm_block_scaled(x_fp8, w_fp8, xs_lhs, xs_rhs))
+
+
+def run_profiled(
+    x_fp8: torch.Tensor,
+    w_fp8: torch.Tensor,
+    xs_lhs: torch.Tensor,
+    xs_rhs: torch.Tensor,
+    profiler_buffer: torch.Tensor,
+) -> torch.Tensor:
+    return clone_result(
+        symm_gemm_block_scaled(
+            x_fp8,
+            w_fp8,
+            xs_lhs,
+            xs_rhs,
+            enable_cuda_profiler=True,
+            profiler_buffer=profiler_buffer,
+        )
+    )
+
+
+def compare_tensors(name: str, actual: torch.Tensor, expected: torch.Tensor) -> Dict[str, float]:
+    actual_f = actual.float()
+    expected_f = expected.float()
+    abs_diff = (actual_f - expected_f).abs()
+    mismatch = actual != expected
+    mismatch_count = int(mismatch.sum().item())
+    total = actual.numel()
+
+    if mismatch_count == 0:
+        stats = {
+            "mismatch_count": 0,
+            "mismatch_pct": 0.0,
+            "max_abs": 0.0,
+            "max_rel": 0.0,
+            "max_index_flat": -1,
+        }
+    else:
+        flat_abs = abs_diff.flatten()
+        max_abs, max_idx = flat_abs.max(dim=0)
+        rel = abs_diff / expected_f.abs().clamp_min(1e-12)
+        max_rel = rel.flatten().max()
+        stats = {
+            "mismatch_count": mismatch_count,
+            "mismatch_pct": mismatch_count / total * 100.0,
+            "max_abs": float(max_abs.item()),
+            "max_rel": float(max_rel.item()),
+            "max_index_flat": int(max_idx.item()),
+        }
+
+    print(
+        f"{name:<32} mismatches={stats['mismatch_count']:>8}/{total} "
+        f"({stats['mismatch_pct']:.4f}%) "
+        f"max_abs={stats['max_abs']:.6g} max_rel={stats['max_rel']:.6g} "
+        f"flat_idx={stats['max_index_flat']}"
+    )
+    return stats
+
+
+def run_correctness_probe(m: int, runs: int) -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this correctness probe")
+
+    x_fp8, w_fp8, xs_lhs, xs_rhs = make_inputs(m)
+    profiler_capacity = estimate_cuda_profiler_records(m, m, m)
+    profiler_buffer = allocate_cuda_profiler_buffer(profiler_capacity, x_fp8.device)
+
+    baseline_outputs: List[torch.Tensor] = []
+    profiled_outputs: List[torch.Tensor] = []
+
+    print(f"CUDA ThunderMoun correctness probe: M=N=K={m}, runs={runs}")
+    print("Running baseline kernels...")
+    for i in range(runs):
+        baseline_outputs.append(run_baseline(x_fp8, w_fp8, xs_lhs, xs_rhs))
+        print(f"  baseline run {i} done")
+
+    print("Running profiled kernels...")
+    for i in range(runs):
+        profiled_outputs.append(run_profiled(x_fp8, w_fp8, xs_lhs, xs_rhs, profiler_buffer))
+        print(f"  profiled run {i} done")
+
+    print("\nWithin-mode consistency:")
+    for i in range(1, runs):
+        compare_tensors(f"baseline[0] vs baseline[{i}]", baseline_outputs[i], baseline_outputs[0])
+    for i in range(1, runs):
+        compare_tensors(f"profiled[0] vs profiled[{i}]", profiled_outputs[i], profiled_outputs[0])
+
+    print("\nBaseline vs profiled:")
+    for i in range(runs):
+        compare_tensors(f"baseline[{i}] vs profiled[{i}]", profiled_outputs[i], baseline_outputs[i])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check ThunderMoun CUDA baseline/profiled output consistency."
+    )
+    parser.add_argument("--m", type=int, default=1024)
+    parser.add_argument("--runs", type=int, default=2)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run_correctness_probe(m=args.m, runs=args.runs)

--- a/jit_kernel/csrc/thunder_moun/profiler.cuh
+++ b/jit_kernel/csrc/thunder_moun/profiler.cuh
@@ -1,0 +1,514 @@
+/* Copyright 2026 flashFloat authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+==============================================================================*/
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+namespace ffjk {
+
+enum CudaProfilerEventKind : uint32_t {
+    kProfilerEventInstant = 0,
+    kProfilerEventBegin = 1,
+    kProfilerEventEnd = 2,
+};
+
+enum CudaProfilerEventId : uint32_t {
+    kProfilerEventKernelEnter = 1,
+    kProfilerEventPipelineEnter = 2,
+    kProfilerEventTask = 10,
+    kProfilerEventTaskMap = 11,
+    kProfilerEventPrefetchTma = 20,
+    kProfilerEventScaleXLoad = 21,
+    kProfilerEventScaleWLoad = 22,
+    kProfilerEventTmaWait = 30,
+    kProfilerEventMmaIssue = 31,
+    kProfilerEventProducerLoadOnce = 32,
+    kProfilerEventWgmmaWait = 33,
+    kProfilerEventScaleApplyAccum = 34,
+    kProfilerEventEpilogueSmemStore = 40,
+    kProfilerEventSplitKReduce = 41,
+    kProfilerEventStoreLower = 42,
+    kProfilerEventMirrorTranspose = 43,
+    kProfilerEventMirrorStore = 44,
+    kProfilerEventTaskDone = 50,
+};
+
+struct alignas(32) CudaProfilerHeader {
+    uint32_t capacity;
+    uint32_t grid_xy;
+    uint32_t records_per_cta;
+    uint32_t records_per_task;
+    uint32_t max_tasks_per_cta;
+    uint32_t max_k_tiles_per_task;
+    uint32_t cta_slots;
+    uint32_t per_k_slots;
+};
+
+struct alignas(16) CudaProfilerRecord {
+    uint64_t timestamp;
+    uint32_t payload;
+    uint16_t tag;
+    uint16_t smid;
+};
+
+struct alignas(32) CudaProfilerBuffer {
+    CudaProfilerHeader header;
+};
+
+struct CudaProfilerLayout {
+    CudaProfilerBuffer* buffer;
+    uint32_t cta_id;
+    uint32_t records_per_cta;
+    uint32_t records_per_task;
+    uint32_t max_tasks_per_cta;
+    uint32_t max_k_tiles_per_task;
+};
+
+static constexpr uint32_t kCudaProfilerCtaSlots = 2;
+static constexpr uint32_t kCudaProfilerTaskSlots = 20;
+static constexpr uint32_t kCudaProfilerPerKSlots = 10;
+
+static constexpr int32_t kCudaProfilerInvalidSlot = -1;
+static constexpr uint32_t kCudaProfilerTagEventBits = 8;
+static constexpr uint32_t kCudaProfilerTagKindShift = 8;
+static constexpr uint32_t kCudaProfilerTagFlagsShift = 10;
+
+static constexpr uint32_t kProfilerCtaSlotKernelEnter = 0;
+static constexpr uint32_t kProfilerCtaSlotPipelineEnter = 1;
+
+static constexpr uint32_t kProfilerTaskSlotTaskBegin = 0;
+static constexpr uint32_t kProfilerTaskSlotTaskMap = 1;
+static constexpr uint32_t kProfilerTaskSlotPrefetchTmaBegin = 2;
+static constexpr uint32_t kProfilerTaskSlotPrefetchTmaEnd = 3;
+static constexpr uint32_t kProfilerTaskSlotScaleXLoadBegin = 4;
+static constexpr uint32_t kProfilerTaskSlotScaleXLoadEnd = 5;
+static constexpr uint32_t kProfilerTaskSlotScaleWLoadBegin = 6;
+static constexpr uint32_t kProfilerTaskSlotScaleWLoadEnd = 7;
+static constexpr uint32_t kProfilerTaskSlotEpilogueSmemStoreBegin = 8;
+static constexpr uint32_t kProfilerTaskSlotEpilogueSmemStoreEnd = 9;
+static constexpr uint32_t kProfilerTaskSlotSplitKReduceBegin = 10;
+static constexpr uint32_t kProfilerTaskSlotSplitKReduceEnd = 11;
+static constexpr uint32_t kProfilerTaskSlotStoreLowerBegin = 12;
+static constexpr uint32_t kProfilerTaskSlotStoreLowerEnd = 13;
+static constexpr uint32_t kProfilerTaskSlotMirrorTransposeBegin = 14;
+static constexpr uint32_t kProfilerTaskSlotMirrorTransposeEnd = 15;
+static constexpr uint32_t kProfilerTaskSlotMirrorStoreBegin = 16;
+static constexpr uint32_t kProfilerTaskSlotMirrorStoreEnd = 17;
+static constexpr uint32_t kProfilerTaskSlotTaskEnd = 18;
+static constexpr uint32_t kProfilerTaskSlotTaskDone = 19;
+
+static constexpr uint32_t kProfilerKSlotTmaWaitBegin = 0;
+static constexpr uint32_t kProfilerKSlotTmaWaitEnd = 1;
+static constexpr uint32_t kProfilerKSlotMmaIssueBegin = 2;
+static constexpr uint32_t kProfilerKSlotMmaIssueEnd = 3;
+static constexpr uint32_t kProfilerKSlotProducerLoadOnceBegin = 4;
+static constexpr uint32_t kProfilerKSlotProducerLoadOnceEnd = 5;
+static constexpr uint32_t kProfilerKSlotWgmmaWaitBegin = 6;
+static constexpr uint32_t kProfilerKSlotWgmmaWaitEnd = 7;
+static constexpr uint32_t kProfilerKSlotScaleApplyAccumBegin = 8;
+static constexpr uint32_t kProfilerKSlotScaleApplyAccumEnd = 9;
+
+static constexpr uint32_t kCudaProfilerHeaderU64Words =
+    sizeof(CudaProfilerHeader) / sizeof(uint64_t);
+static constexpr uint32_t kCudaProfilerRecordU64Words =
+    sizeof(CudaProfilerRecord) / sizeof(uint64_t);
+
+static_assert(sizeof(CudaProfilerHeader) % sizeof(uint64_t) == 0,
+              "CudaProfilerHeader must be uint64_t-aligned for Python tensor allocation.");
+static_assert(sizeof(CudaProfilerHeader) == 32,
+              "CudaProfilerHeader must stay 32 bytes to keep records aligned.");
+static_assert(sizeof(CudaProfilerRecord) == 16,
+              "CudaProfilerRecord must stay 16 bytes for low-overhead host parsing.");
+
+__host__ __device__ __forceinline__ uint32_t cuda_profiler_pack_u16(
+    uint32_t lo,
+    uint32_t hi) {
+    return (lo & 0xffffu) | ((hi & 0xffffu) << 16);
+}
+
+__host__ __device__ __forceinline__ uint16_t cuda_profiler_make_tag(
+    uint32_t event_id,
+    CudaProfilerEventKind kind,
+    uint32_t flags = 0) {
+    return static_cast<uint16_t>(
+        (event_id & ((1u << kCudaProfilerTagEventBits) - 1u)) |
+        ((static_cast<uint32_t>(kind) & 0x3u) << kCudaProfilerTagKindShift) |
+        ((flags & 0x3fu) << kCudaProfilerTagFlagsShift));
+}
+
+__host__ __device__ __forceinline__ uint32_t cuda_profiler_compact_payload(
+    uint32_t event_id,
+    uint32_t payload0,
+    uint32_t payload1) {
+    switch (event_id) {
+    case kProfilerEventKernelEnter:
+        return cuda_profiler_pack_u16(payload0, payload1);
+    case kProfilerEventTask:
+        return payload0;
+    default:
+        return payload1 != 0 ? payload1 : payload0;
+    }
+}
+
+__host__ __device__ __forceinline__ uint32_t cuda_profiler_records_per_task(
+    uint32_t max_k_tiles_per_task) {
+    return kCudaProfilerTaskSlots + max_k_tiles_per_task * kCudaProfilerPerKSlots;
+}
+
+__host__ __device__ __forceinline__ uint32_t cuda_profiler_records_per_cta(
+    uint32_t max_tasks_per_cta,
+    uint32_t max_k_tiles_per_task) {
+    return kCudaProfilerCtaSlots +
+           max_tasks_per_cta * cuda_profiler_records_per_task(max_k_tiles_per_task);
+}
+
+__host__ __device__ __forceinline__ uint32_t cuda_profiler_required_records(
+    uint32_t num_ctas,
+    uint32_t max_tasks_per_cta,
+    uint32_t max_k_tiles_per_task) {
+    return num_ctas *
+           cuda_profiler_records_per_cta(max_tasks_per_cta, max_k_tiles_per_task);
+}
+
+inline cudaError_t cuda_profiler_init(
+    void* raw_buffer,
+    uint32_t capacity,
+    uint32_t grid_x,
+    uint32_t grid_y,
+    uint32_t max_tasks_per_cta,
+    uint32_t max_k_tiles_per_task,
+    cudaStream_t stream) {
+    if (raw_buffer == nullptr || capacity == 0) {
+        return cudaSuccess;
+    }
+
+    cudaError_t memset_state = cudaMemsetAsync(
+        raw_buffer,
+        0,
+        sizeof(CudaProfilerHeader) + static_cast<size_t>(capacity) * sizeof(CudaProfilerRecord),
+        stream);
+    if (memset_state != cudaSuccess) {
+        return memset_state;
+    }
+
+    CudaProfilerHeader header{};
+    header.capacity = capacity;
+    header.grid_xy = cuda_profiler_pack_u16(grid_x, grid_y);
+    header.max_tasks_per_cta = max_tasks_per_cta;
+    header.max_k_tiles_per_task = max_k_tiles_per_task;
+    header.records_per_task = cuda_profiler_records_per_task(max_k_tiles_per_task);
+    header.records_per_cta = cuda_profiler_records_per_cta(
+        max_tasks_per_cta, max_k_tiles_per_task);
+    header.cta_slots = kCudaProfilerCtaSlots;
+    header.per_k_slots = kCudaProfilerPerKSlots;
+
+    return cudaMemcpyAsync(
+        raw_buffer, &header, sizeof(header), cudaMemcpyHostToDevice, stream);
+}
+
+#if defined(__CUDA_ARCH__)
+
+__device__ __forceinline__ uint64_t cuda_profiler_read_timestamp() {
+    uint64_t timestamp;
+    asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(timestamp));
+    return timestamp;
+}
+
+__device__ __forceinline__ uint32_t cuda_profiler_read_smid() {
+    uint32_t smid;
+    asm volatile("mov.u32 %0, %%smid;" : "=r"(smid));
+    return smid;
+}
+
+__device__ __forceinline__ CudaProfilerRecord* cuda_profiler_records(
+    CudaProfilerBuffer* buffer) {
+    return reinterpret_cast<CudaProfilerRecord*>(
+        reinterpret_cast<unsigned char*>(buffer) + sizeof(CudaProfilerHeader));
+}
+
+__device__ __forceinline__ CudaProfilerLayout cuda_profiler_make_layout(
+    CudaProfilerBuffer* buffer,
+    uint32_t total_symmetric_tiles,
+    uint32_t max_k_tiles_per_task) {
+    CudaProfilerLayout layout{};
+    layout.buffer = buffer;
+    if (buffer == nullptr) {
+        return layout;
+    }
+
+    layout.cta_id = (blockIdx.z * gridDim.y + blockIdx.y) * gridDim.x + blockIdx.x;
+    layout.max_tasks_per_cta = (total_symmetric_tiles + gridDim.y - 1) / gridDim.y;
+    layout.max_k_tiles_per_task = max_k_tiles_per_task;
+    layout.records_per_task = cuda_profiler_records_per_task(max_k_tiles_per_task);
+    layout.records_per_cta = cuda_profiler_records_per_cta(
+        layout.max_tasks_per_cta, max_k_tiles_per_task);
+    return layout;
+}
+
+__device__ __forceinline__ int32_t cuda_profiler_cta_slot(
+    uint32_t event_id,
+    CudaProfilerEventKind kind) {
+    if (kind != kProfilerEventInstant) {
+        return kCudaProfilerInvalidSlot;
+    }
+
+    switch (event_id) {
+    case kProfilerEventKernelEnter:
+        return kProfilerCtaSlotKernelEnter;
+    case kProfilerEventPipelineEnter:
+        return kProfilerCtaSlotPipelineEnter;
+    default:
+        return kCudaProfilerInvalidSlot;
+    }
+}
+
+__device__ __forceinline__ int32_t cuda_profiler_task_slot(
+    uint32_t event_id,
+    CudaProfilerEventKind kind) {
+    switch (event_id) {
+    case kProfilerEventTask:
+        if (kind == kProfilerEventBegin) {
+            return kProfilerTaskSlotTaskBegin;
+        }
+        if (kind == kProfilerEventEnd) {
+            return kProfilerTaskSlotTaskEnd;
+        }
+        return kCudaProfilerInvalidSlot;
+    case kProfilerEventTaskMap:
+        return kind == kProfilerEventInstant
+                   ? kProfilerTaskSlotTaskMap
+                   : kCudaProfilerInvalidSlot;
+    case kProfilerEventPrefetchTma:
+        return kind == kProfilerEventBegin
+                   ? kProfilerTaskSlotPrefetchTmaBegin
+                   : (kind == kProfilerEventEnd ? kProfilerTaskSlotPrefetchTmaEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventScaleXLoad:
+        return kind == kProfilerEventBegin
+                   ? kProfilerTaskSlotScaleXLoadBegin
+                   : (kind == kProfilerEventEnd ? kProfilerTaskSlotScaleXLoadEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventScaleWLoad:
+        return kind == kProfilerEventBegin
+                   ? kProfilerTaskSlotScaleWLoadBegin
+                   : (kind == kProfilerEventEnd ? kProfilerTaskSlotScaleWLoadEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventEpilogueSmemStore:
+        return kind == kProfilerEventBegin
+                   ? kProfilerTaskSlotEpilogueSmemStoreBegin
+                   : (kind == kProfilerEventEnd ? kProfilerTaskSlotEpilogueSmemStoreEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventSplitKReduce:
+        return kind == kProfilerEventBegin
+                   ? kProfilerTaskSlotSplitKReduceBegin
+                   : (kind == kProfilerEventEnd ? kProfilerTaskSlotSplitKReduceEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventStoreLower:
+        return kind == kProfilerEventBegin
+                   ? kProfilerTaskSlotStoreLowerBegin
+                   : (kind == kProfilerEventEnd ? kProfilerTaskSlotStoreLowerEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventMirrorTranspose:
+        return kind == kProfilerEventBegin
+                   ? kProfilerTaskSlotMirrorTransposeBegin
+                   : (kind == kProfilerEventEnd ? kProfilerTaskSlotMirrorTransposeEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventMirrorStore:
+        return kind == kProfilerEventBegin
+                   ? kProfilerTaskSlotMirrorStoreBegin
+                   : (kind == kProfilerEventEnd ? kProfilerTaskSlotMirrorStoreEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventTaskDone:
+        return kind == kProfilerEventInstant
+                   ? kProfilerTaskSlotTaskDone
+                   : kCudaProfilerInvalidSlot;
+    default:
+        return kCudaProfilerInvalidSlot;
+    }
+}
+
+__device__ __forceinline__ int32_t cuda_profiler_k_slot(
+    uint32_t event_id,
+    CudaProfilerEventKind kind) {
+    switch (event_id) {
+    case kProfilerEventTmaWait:
+        return kind == kProfilerEventBegin
+                   ? kProfilerKSlotTmaWaitBegin
+                   : (kind == kProfilerEventEnd ? kProfilerKSlotTmaWaitEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventMmaIssue:
+        return kind == kProfilerEventBegin
+                   ? kProfilerKSlotMmaIssueBegin
+                   : (kind == kProfilerEventEnd ? kProfilerKSlotMmaIssueEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventProducerLoadOnce:
+        return kind == kProfilerEventBegin
+                   ? kProfilerKSlotProducerLoadOnceBegin
+                   : (kind == kProfilerEventEnd ? kProfilerKSlotProducerLoadOnceEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventWgmmaWait:
+        return kind == kProfilerEventBegin
+                   ? kProfilerKSlotWgmmaWaitBegin
+                   : (kind == kProfilerEventEnd ? kProfilerKSlotWgmmaWaitEnd
+                                                : kCudaProfilerInvalidSlot);
+    case kProfilerEventScaleApplyAccum:
+        return kind == kProfilerEventBegin
+                   ? kProfilerKSlotScaleApplyAccumBegin
+                   : (kind == kProfilerEventEnd ? kProfilerKSlotScaleApplyAccumEnd
+                                                : kCudaProfilerInvalidSlot);
+    default:
+        return kCudaProfilerInvalidSlot;
+    }
+}
+
+__device__ __forceinline__ void cuda_profiler_record_slot(
+    const CudaProfilerLayout& layout,
+    uint64_t slot,
+    uint32_t event_id,
+    CudaProfilerEventKind kind,
+    uint32_t payload0,
+    uint32_t payload1) {
+    if (layout.buffer == nullptr || slot >= layout.buffer->header.capacity) {
+        return;
+    }
+
+    CudaProfilerRecord* records = cuda_profiler_records(layout.buffer);
+    CudaProfilerRecord& record = records[slot];
+    record.timestamp = cuda_profiler_read_timestamp();
+    record.payload = cuda_profiler_compact_payload(event_id, payload0, payload1);
+    record.tag = cuda_profiler_make_tag(event_id, kind);
+    record.smid = static_cast<uint16_t>(cuda_profiler_read_smid());
+}
+
+__device__ __forceinline__ void cuda_profiler_record_cta_event(
+    const CudaProfilerLayout& layout,
+    uint32_t event_id,
+    CudaProfilerEventKind kind,
+    uint32_t payload0,
+    uint32_t payload1) {
+    int32_t slot_in_cta = cuda_profiler_cta_slot(event_id, kind);
+    if (slot_in_cta < 0) {
+        return;
+    }
+
+    uint64_t slot = static_cast<uint64_t>(layout.cta_id) * layout.records_per_cta +
+                    static_cast<uint32_t>(slot_in_cta);
+    cuda_profiler_record_slot(layout, slot, event_id, kind, payload0, payload1);
+}
+
+__device__ __forceinline__ void cuda_profiler_record_task_event(
+    const CudaProfilerLayout& layout,
+    uint32_t task_iter,
+    int32_t k_iter,
+    uint32_t event_id,
+    CudaProfilerEventKind kind,
+    uint32_t payload0,
+    uint32_t payload1) {
+    int32_t slot_in_task = cuda_profiler_task_slot(event_id, kind);
+    if (slot_in_task < 0) {
+        int32_t slot_in_k = cuda_profiler_k_slot(event_id, kind);
+        if (slot_in_k < 0 || k_iter < 0 ||
+            static_cast<uint32_t>(k_iter) >= layout.max_k_tiles_per_task) {
+            return;
+        }
+        slot_in_task = static_cast<int32_t>(
+            kCudaProfilerTaskSlots +
+            static_cast<uint32_t>(k_iter) * kCudaProfilerPerKSlots +
+            static_cast<uint32_t>(slot_in_k));
+    }
+
+    if (task_iter >= layout.max_tasks_per_cta) {
+        return;
+    }
+
+    uint64_t cta_base = static_cast<uint64_t>(layout.cta_id) * layout.records_per_cta;
+    uint64_t task_base = static_cast<uint64_t>(task_iter) * layout.records_per_task;
+    uint64_t slot = cta_base + kCudaProfilerCtaSlots + task_base +
+                    static_cast<uint32_t>(slot_in_task);
+    cuda_profiler_record_slot(layout, slot, event_id, kind, payload0, payload1);
+}
+
+#endif // defined(__CUDA_ARCH__)
+
+} // namespace ffjk
+
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+
+#define FFJK_PROFILER_KERNEL_PARAMS , ffjk::CudaProfilerBuffer* ffjk_profiler
+#define FFJK_PROFILER_KERNEL_ARGS , ffjk_profiler
+#define FFJK_PROFILER_LAUNCH_ARG(profiler) , profiler
+
+#define FFJK_PROFILER_DEFINE_LAYOUT(total_symmetric_tiles, max_k_tiles_per_task)    \
+    ffjk::CudaProfilerLayout ffjk_prof_layout = ffjk::cuda_profiler_make_layout(    \
+        ffjk_profiler,                                                              \
+        static_cast<uint32_t>(total_symmetric_tiles),                               \
+        static_cast<uint32_t>(max_k_tiles_per_task))
+
+#define FFJK_PROF_CTA_EVENT_PAYLOAD(event_id, payload0, payload1)                  \
+    do {                                                                            \
+        if (threadIdx.x == 0) {                                                     \
+            ffjk::cuda_profiler_record_cta_event(                                   \
+                ffjk_prof_layout, event_id, ffjk::kProfilerEventInstant,            \
+                static_cast<uint32_t>(payload0), static_cast<uint32_t>(payload1));  \
+        }                                                                           \
+    } while (0)
+
+#define FFJK_PROF_EVENT(event_id)                                                   \
+    do {                                                                            \
+        if (threadIdx.x == 0) {                                                     \
+            ffjk::cuda_profiler_record_task_event(                                  \
+                ffjk_prof_layout, static_cast<uint32_t>(ffjk_prof_task_iter),       \
+                static_cast<int32_t>(ffjk_prof_k_iter), event_id,                   \
+                ffjk::kProfilerEventInstant, 0, 0);                                 \
+        }                                                                           \
+    } while (0)
+
+#define FFJK_PROF_EVENT_PAYLOAD(event_id, payload0, payload1)                       \
+    do {                                                                            \
+        if (threadIdx.x == 0) {                                                     \
+            ffjk::cuda_profiler_record_task_event(                                  \
+                ffjk_prof_layout, static_cast<uint32_t>(ffjk_prof_task_iter),       \
+                static_cast<int32_t>(ffjk_prof_k_iter), event_id,                   \
+                ffjk::kProfilerEventInstant,                                        \
+                static_cast<uint32_t>(payload0), static_cast<uint32_t>(payload1));  \
+        }                                                                           \
+    } while (0)
+
+#define FFJK_PROF_BEGIN(event_id, payload0, payload1)                               \
+    do {                                                                            \
+        if (threadIdx.x == 0) {                                                     \
+            ffjk::cuda_profiler_record_task_event(                                  \
+                ffjk_prof_layout, static_cast<uint32_t>(ffjk_prof_task_iter),       \
+                static_cast<int32_t>(ffjk_prof_k_iter), event_id,                   \
+                ffjk::kProfilerEventBegin,                                          \
+                static_cast<uint32_t>(payload0), static_cast<uint32_t>(payload1));  \
+        }                                                                           \
+    } while (0)
+
+#define FFJK_PROF_END(event_id, payload0, payload1)                                 \
+    do {                                                                            \
+        if (threadIdx.x == 0) {                                                     \
+            ffjk::cuda_profiler_record_task_event(                                  \
+                ffjk_prof_layout, static_cast<uint32_t>(ffjk_prof_task_iter),       \
+                static_cast<int32_t>(ffjk_prof_k_iter), event_id,                   \
+                ffjk::kProfilerEventEnd,                                            \
+                static_cast<uint32_t>(payload0), static_cast<uint32_t>(payload1));  \
+        }                                                                           \
+    } while (0)
+
+#else
+
+#define FFJK_PROFILER_KERNEL_PARAMS
+#define FFJK_PROFILER_KERNEL_ARGS
+#define FFJK_PROFILER_LAUNCH_ARG(profiler)
+#define FFJK_PROFILER_DEFINE_LAYOUT(total_symmetric_tiles, max_k_tiles_per_task)
+#define FFJK_PROF_CTA_EVENT_PAYLOAD(event_id, payload0, payload1) do {} while (0)
+#define FFJK_PROF_EVENT(event_id) do {} while (0)
+#define FFJK_PROF_EVENT_PAYLOAD(event_id, payload0, payload1) do {} while (0)
+#define FFJK_PROF_BEGIN(event_id, payload0, payload1) do {} while (0)
+#define FFJK_PROF_END(event_id, payload0, payload1) do {} while (0)
+
+#endif // FFJK_ENABLE_CUDA_PROFILER

--- a/jit_kernel/csrc/thunder_moun/symm_gemm.cu
+++ b/jit_kernel/csrc/thunder_moun/symm_gemm.cu
@@ -54,6 +54,7 @@ namespace cg = cooperative_groups;
 
 #include "tensor/tuple.h"
 #include "tensor/tensor_view_ref.h"
+#include "profiler.cuh"
 #include "fragment/fragment.h"
 
 // TODO (yiakwy) : move to xpu general interface
@@ -102,7 +103,8 @@ void hopper_symm_gemm_kernel_entry(
     __grid_constant__ const CUtensorMap tma_desc_X,
     __grid_constant__ const CUtensorMap tma_desc_W,
     __grid_constant__ const CUtensorMap tma_desc_O,
-    __grid_constant__ const CUtensorMap tma_desc_O_swizzle)
+    __grid_constant__ const CUtensorMap tma_desc_O_swizzle
+    FFJK_PROFILER_KERNEL_PARAMS)
 {
     // extern __shared__ uint8_t total_smem_space[];
     extern __shared__ __align__(128) uint8_t smem_buffer[];
@@ -112,6 +114,16 @@ void hopper_symm_gemm_kernel_entry(
     uintptr_t aligned_smem = (raw_smem + 127) & ~127;
     uint8_t* smem_buffer = reinterpret_cast<uint8_t*>(aligned_smem);
     */
+
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+    const int profiler_k_tiles_total = CEILDIV(K, K_BLOCK_K);
+    const int profiler_k_tiles_per_slice = CEILDIV(profiler_k_tiles_total, gridDim.x);
+    FFJK_PROFILER_DEFINE_LAYOUT(total_symmetric_tiles, profiler_k_tiles_per_slice);
+    FFJK_PROF_CTA_EVENT_PAYLOAD(
+        ffjk::kProfilerEventKernelEnter,
+        M,
+        N);
+#endif
 
     xpu::HopperWGMMAAccumulator<K_BLOCK_M, K_BLOCK_N, K_BLOCK_K> accumulator_fragment;
     accumulator_fragment.clear();
@@ -135,6 +147,7 @@ void hopper_symm_gemm_kernel_entry(
             num_blocks_m,
             num_blocks_n,
             smem_buffer
+            FFJK_PROFILER_KERNEL_ARGS
         );
     } else
     if (cluster_size_m < 4) {
@@ -151,6 +164,7 @@ void hopper_symm_gemm_kernel_entry(
             num_blocks_m,
             num_blocks_n,
             smem_buffer
+            FFJK_PROFILER_KERNEL_ARGS
         );
     } else
     if (cluster_size_m < 2) {
@@ -167,6 +181,7 @@ void hopper_symm_gemm_kernel_entry(
             num_blocks_m,
             num_blocks_n,
             smem_buffer
+            FFJK_PROFILER_KERNEL_ARGS
         );
     }
 
@@ -180,12 +195,24 @@ extern "C" int symm_gemm_fp8_block_scaled(
     int w_stride_n, int w_stride_k,
     int o_stride_m, int o_stride_n,
     unsigned int split_k,
-    cudaStream_t stream = 0)
+    cudaStream_t stream = 0
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+    , void* profiler_buffer = nullptr,
+    unsigned int profiler_capacity = 0
+#endif
+    )
 {
     using fp8_t = __nv_fp8_e4m3;
     using fp16_t = half;
     using bf16_t = __nv_bfloat16;
     using fp32_t = float;
+
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+    ffjk::CudaProfilerBuffer* profiler = nullptr;
+    if (profiler_buffer != nullptr && profiler_capacity > 0) {
+        profiler = reinterpret_cast<ffjk::CudaProfilerBuffer*>(profiler_buffer);
+    }
+#endif
 
 // TODO(yiakwy) : move to op constructor
 /*
@@ -369,6 +396,27 @@ extern "C" int symm_gemm_fp8_block_scaled(
     dim3 grid(split_k, grid_mn, 1);
     dim3 block(TOTAL_WARP_THREADS, 1, 1);
 
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+    if (profiler != nullptr) {
+        const uint32_t k_tiles_total = CEILDIV(K, K_BLOCK_K);
+        const uint32_t k_tiles_per_slice = CEILDIV(k_tiles_total, split_k);
+        const uint32_t max_tasks_per_cta = CEILDIV(total_symmetric_tiles, grid_mn);
+
+        cudaError_t init_state = ffjk::cuda_profiler_init(
+            profiler_buffer,
+            profiler_capacity,
+            grid.x,
+            grid.y,
+            max_tasks_per_cta,
+            k_tiles_per_slice,
+            stream);
+        if (init_state != cudaSuccess) {
+            printf("[ERROR] cuda profiler init failed: %s\n", cudaGetErrorString(init_state));
+            return -1;
+        }
+    }
+#endif
+
 #if __CUDA_ARCH__ >= 900 && ENABLE_HOPPER // Hopper 900+ GPU with TMA support
     cudaLaunchConfig_t launch_config = {0};
     launch_config.gridDim = grid;
@@ -390,6 +438,7 @@ extern "C" int symm_gemm_fp8_block_scaled(
     cudaError_t state = cudaLaunchKernelEx(&launch_config, kernel,
         (const fp8_t*)X_ptr, (const fp8_t*)W_ptr, (const fp32_t*)scale_X, (fp32_t*)scale_W, (fp16_t*)Out_ptr,
         M, N, K, total_symmetric_tiles, num_blocks_m, num_blocks_n, cluster_size_m, desc_X, desc_W, desc_O, desc_O_swizzle
+        FFJK_PROFILER_LAUNCH_ARG(profiler)
     );
 
     if (state != cudaSuccess) {
@@ -432,7 +481,36 @@ void tvm_jit_symm_gemm_fp8_block_scaled_launch(
     );
 }
 
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+void tvm_jit_symm_gemm_fp8_block_scaled_profiled_launch(
+    TensorView X, TensorView W, TensorView scale_X, TensorView scale_W, TensorView Out,
+    int M, int N, int K,
+    int x_stride_m, int x_stride_k,
+    int w_stride_n, int w_stride_k,
+    int o_stride_m, int o_stride_n,
+    unsigned int split_k,
+    TensorView profiler_buffer,
+    int profiler_capacity)
+{
+    DLDevice device = X.device();
+    cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
+
+    symm_gemm_fp8_block_scaled(
+        X.data_ptr(), W.data_ptr(), scale_X.data_ptr(), scale_W.data_ptr(), Out.data_ptr(),
+        M, N, K,
+        x_stride_m, x_stride_k,
+        w_stride_n, w_stride_k,
+        o_stride_m, o_stride_n,
+        split_k, stream,
+        profiler_buffer.data_ptr(), static_cast<unsigned int>(profiler_capacity)
+    );
+}
+#endif
+
 } // namespace tvm_c_loader
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(symmetric_gemm_fp8_block_scaled, (tvm_c_loader::tvm_jit_symm_gemm_fp8_block_scaled_launch));
+#ifdef FFJK_ENABLE_CUDA_PROFILER
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(symmetric_gemm_fp8_block_scaled_profiled, (tvm_c_loader::tvm_jit_symm_gemm_fp8_block_scaled_profiled_launch));
+#endif
 #endif

--- a/jit_kernel/thunder_moun.py
+++ b/jit_kernel/thunder_moun.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import os
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 os.environ["TVM_FFI_CUDA_ARCH_LIST"] = (
     "9.0a"  # Set the CUDA architecture to 9.0 for Hopper support
@@ -27,6 +27,7 @@ extra_ldflags = ["-lcudart", "-lcuda"]
 
 cuda_sources = [
     str(KERNEL_PATH / "csrc" / "thunder_moun/symm_gemm.cu"),
+    str(KERNEL_PATH / "csrc" / "thunder_moun/profiler.cuh"),
     str(KERNEL_PATH / "csrc" / "thunder_moun/arch/tma/tma_desc.h"),
     str(KERNEL_PATH / "csrc" / "thunder_moun/arch/tma/tma_desc_impl.h"),
     str(KERNEL_PATH / "csrc" / "thunder_moun/arch/tma/tma_copy.h"),
@@ -71,7 +72,7 @@ if major >= 9:
 
 
 @functools.cache
-def _jit_thunder_moun_module():
+def _jit_thunder_moun_module(enable_cuda_profiler: bool = False):
     if USE_TORCH_JIT:
         raise Exception(
             "Torch JIT is not supported for thunder moun kernel, please set USE_TORCH_JIT to False"
@@ -79,13 +80,18 @@ def _jit_thunder_moun_module():
     else:
 
         cuda_tmp_sources = [f'#include "{path}"' for path in cuda_sources]
+        extra_cuda_cflags = list(common_cuda_flags)
+        module_name = "thunder_moun"
+        if enable_cuda_profiler:
+            extra_cuda_cflags.append("-DFFJK_ENABLE_CUDA_PROFILER=1")
+            module_name = "thunder_moun_profiler"
 
         return load_jit(
-            "thunder_moun",
+            module_name,
             cuda_sources=cuda_tmp_sources,
             # TODO (yiakwy) : add sglang style TVM_FFI warpper
             # cuda_wrappers=[(_PY_SYMBOL, _CPP_ENTRY)],
-            extra_cuda_cflags=common_cuda_flags,
+            extra_cuda_cflags=extra_cuda_cflags,
             extra_ldflags=extra_ldflags,
         )
 
@@ -94,7 +100,120 @@ def is_column_major(tensor: torch.Tensor):
     return tensor.stride()[0] == 1 and tensor.stride()[1] > 1
 
 
+BLK_M = 128
+BLK_N = 128
 BLK_K = 128
+DEFAULT_SM_COUNT = 132
+MAX_SPLIT_K = 8
+CLUSTER_SIZE_M = 2
+
+CUDA_PROFILER_HEADER_U64_WORDS = 4
+CUDA_PROFILER_RECORD_U64_WORDS = 2
+CUDA_PROFILER_CTA_SLOTS = 2
+CUDA_PROFILER_TASK_SLOTS = 20
+CUDA_PROFILER_PER_K_SLOTS = 10
+
+
+def allocate_cuda_profiler_buffer(
+    max_records: int,
+    device: Union[torch.device, str],
+) -> torch.Tensor:
+    assert max_records > 0, "max_records must be positive"
+    num_words = (
+        CUDA_PROFILER_HEADER_U64_WORDS
+        + max_records * CUDA_PROFILER_RECORD_U64_WORDS
+    )
+    return torch.empty(num_words, device=device, dtype=torch.uint64)
+
+
+def cuda_profiler_capacity(profiler_buffer: torch.Tensor) -> int:
+    assert profiler_buffer.is_cuda, "profiler_buffer must be a CUDA tensor"
+    assert profiler_buffer.dtype == torch.uint64, "profiler_buffer must be torch.uint64"
+    assert profiler_buffer.is_contiguous(), "profiler_buffer must be contiguous"
+    payload_words = profiler_buffer.numel() - CUDA_PROFILER_HEADER_U64_WORDS
+    assert payload_words >= 0, "profiler_buffer is smaller than the profiler header"
+    return payload_words // CUDA_PROFILER_RECORD_U64_WORDS
+
+
+def _ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def _device_sm_count(device: Optional[Union[torch.device, str, int]] = None) -> int:
+    if not torch.cuda.is_available():
+        return DEFAULT_SM_COUNT
+
+    if device is None:
+        device_index = torch.cuda.current_device()
+    elif isinstance(device, int):
+        device_index = device
+    else:
+        torch_device = torch.device(device)
+        device_index = (
+            torch_device.index
+            if torch_device.index is not None
+            else torch.cuda.current_device()
+        )
+
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+def _effective_split_k(
+    total_symmetric_tiles: int,
+    requested_split_k: int,
+    sm_count: int,
+) -> Tuple[int, int]:
+    grid_mn = min(sm_count, total_symmetric_tiles)
+    split_k = requested_split_k
+
+    if grid_mn < sm_count:
+        if grid_mn >= 64:
+            split_k = 2
+        elif grid_mn >= 32:
+            split_k = min(split_k, 4)
+        else:
+            split_k = min(split_k, 8)
+    else:
+        split_k = 1
+
+    cluster_size_m = min(4, CLUSTER_SIZE_M)
+    if grid_mn % cluster_size_m != 0:
+        cluster_size_m = 1
+
+    max_split_k = _ceil_div(MAX_SPLIT_K, cluster_size_m)
+    split_k = min(split_k, max_split_k)
+    return split_k, grid_mn
+
+
+def estimate_cuda_profiler_records(
+    M: int,
+    N: int,
+    K: int,
+    requested_split_k: int = 1,
+    device: Optional[Union[torch.device, str, int]] = None,
+) -> int:
+    num_blocks_m = _ceil_div(M, BLK_M)
+    num_blocks_n = _ceil_div(N, BLK_N)
+    total_symmetric_tiles = (num_blocks_m * num_blocks_n + num_blocks_m) // 2
+    assert total_symmetric_tiles > 0, "profiler requires at least one output tile"
+
+    split_k, grid_mn = _effective_split_k(
+        total_symmetric_tiles,
+        requested_split_k,
+        _device_sm_count(device),
+    )
+    k_tiles_total = _ceil_div(K, BLK_K)
+    max_k_tiles_per_task = _ceil_div(k_tiles_total, split_k)
+    max_tasks_per_cta = _ceil_div(total_symmetric_tiles, grid_mn)
+    records_per_task = (
+        CUDA_PROFILER_TASK_SLOTS
+        + max_k_tiles_per_task * CUDA_PROFILER_PER_K_SLOTS
+    )
+    records_per_cta = (
+        CUDA_PROFILER_CTA_SLOTS + max_tasks_per_cta * records_per_task
+    )
+    num_ctas = split_k * grid_mn
+    return num_ctas * records_per_cta
 
 
 def symm_gemm_block_scaled(
@@ -107,7 +226,10 @@ def symm_gemm_block_scaled(
     SCALE_BLOCK_SIZE_K: int = 128,
     check_input_shape: bool = False,
     use_mxfp8: bool = False,
-) -> torch.Tensor:
+    enable_cuda_profiler: bool = False,
+    profiler_buffer: Optional[torch.Tensor] = None,
+    max_profiler_records: Optional[int] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Thunder Moun Optimizer CUDA Kernel
     Args:
@@ -152,6 +274,44 @@ def symm_gemm_block_scaled(
 
     if out is None:
         out = torch.zeros((M, N), device=xq.device, dtype=torch.float16)
+
+    if enable_cuda_profiler or profiler_buffer is not None:
+        if profiler_buffer is None:
+            profiler_capacity = estimate_cuda_profiler_records(
+                M, N, K, split_k, xq.device
+            )
+            if max_profiler_records is not None:
+                assert max_profiler_records > 0, "max_profiler_records must be positive"
+                profiler_capacity = min(profiler_capacity, max_profiler_records)
+            profiler_buffer = allocate_cuda_profiler_buffer(
+                profiler_capacity, xq.device
+            )
+        else:
+            profiler_capacity = cuda_profiler_capacity(profiler_buffer)
+
+        module = _jit_thunder_moun_module(True)
+
+        module.symmetric_gemm_fp8_block_scaled_profiled(
+            xq,
+            wq,
+            xs_lhs,
+            xs_rhs,
+            out,
+            M,
+            N,
+            K,
+            xq.stride(0),
+            xq.stride(1),
+            wq.stride(0),
+            wq.stride(1),
+            out.stride(0),
+            out.stride(1),
+            split_k,
+            profiler_buffer,
+            profiler_capacity,
+        )
+
+        return out, profiler_buffer
 
     module = _jit_thunder_moun_module()
 

--- a/profiling/cuda_path/README.md
+++ b/profiling/cuda_path/README.md
@@ -1,0 +1,62 @@
+# ThunderMoun CUDA Path Nsight Targets
+
+This folder contains external-profiler targets for the ThunderMoun CUDA path.
+The default target runs the normal non-embedded-profiler path so Nsight Systems
+and Nsight Compute can focus on `hopper_symm_gemm_kernel_entry`.
+
+## Quick Start
+
+```bash
+bash profiling/cuda_path/run_nsys.sh
+bash profiling/cuda_path/run_ncu.sh
+```
+
+The scripts write reports under:
+
+```text
+profiling/cuda_path/results/nsys
+profiling/cuda_path/results/ncu
+```
+
+Open the reports with:
+
+```bash
+nsys-ui profiling/cuda_path/results/nsys/<report>.nsys-rep
+ncu-ui profiling/cuda_path/results/ncu/<report>.ncu-rep
+```
+
+## Common Parameters
+
+Use environment variables to change the default run:
+
+```bash
+M=4096 WARMUP=5 ITERS=50 bash profiling/cuda_path/run_nsys.sh
+M=4096 ITERS=1 SET=full bash profiling/cuda_path/run_ncu.sh
+```
+
+To profile the embedded-profiler route as well:
+
+```bash
+PROFILED=1 bash profiling/cuda_path/run_nsys.sh
+PROFILED=1 bash profiling/cuda_path/run_ncu.sh
+```
+
+When the embedded profiler is enabled, the decoded event summary and Chrome
+trace describe the final profiled launch. Use `ITERS=1` when you want the timing
+loop and embedded trace to refer to exactly the same launch. Profiled timing also
+includes the profiler buffer reset/header copy that happens before each kernel.
+
+The target preallocates the output tensor by default. This keeps PyTorch tensor
+allocation and zero-fill kernels out of the measured loop and makes the Nsight
+reports cleaner for kernel analysis.
+
+## Direct Target Run
+
+```bash
+python profiling/cuda_path/target_symm_gemm_cuda.py --m 4096 --warmup 5 --iters 20
+python profiling/cuda_path/target_symm_gemm_cuda.py --m 4096 --warmup 5 --iters 20 --profiled
+```
+
+The `--cuda-profiler-api` flag is used by the Nsight scripts. It calls
+`cudaProfilerStart` after warmup and `cudaProfilerStop` after the measured loop,
+so the profiler capture range excludes setup and warmup work.

--- a/profiling/cuda_path/results/.gitignore
+++ b/profiling/cuda_path/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/profiling/cuda_path/run_ncu.sh
+++ b/profiling/cuda_path/run_ncu.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+TARGET="${SCRIPT_DIR}/target_symm_gemm_cuda.py"
+OUT_DIR="${SCRIPT_DIR}/results/ncu"
+
+PYTHON="${PYTHON:-python}"
+NCU="${NCU:-ncu}"
+M="${M:-4096}"
+WARMUP="${WARMUP:-2}"
+ITERS="${ITERS:-1}"
+DEVICE="${DEVICE:-cuda}"
+PROFILED="${PROFILED:-0}"
+SET="${SET:-full}"
+KERNEL_NAME="${KERNEL_NAME:-regex:hopper_symm_gemm_kernel_entry}"
+LAUNCH_SKIP="${LAUNCH_SKIP:-0}"
+LAUNCH_COUNT="${LAUNCH_COUNT:-1}"
+OUT="${OUT:-${OUT_DIR}/symm_gemm_cuda_m${M}_$(date +%Y%m%d_%H%M%S)}"
+
+mkdir -p "${OUT_DIR}"
+cd "${REPO_ROOT}"
+
+prewarm_args=(--m "${M}" --warmup 1 --iters 1 --device "${DEVICE}" --no-nvtx)
+target_args=(
+    --m "${M}"
+    --warmup "${WARMUP}"
+    --iters "${ITERS}"
+    --device "${DEVICE}"
+    --cuda-profiler-api
+)
+
+if [[ "${PROFILED}" == "1" ]]; then
+    prewarm_args+=(--profiled)
+    target_args+=(--profiled)
+fi
+
+echo "[ncu] prewarming JIT/cache outside Nsight Compute..."
+"${PYTHON}" "${TARGET}" "${prewarm_args[@]}"
+
+echo "[ncu] writing ${OUT}.ncu-rep"
+"${NCU}" \
+    --force-overwrite \
+    --target-processes all \
+    --profile-from-start off \
+    --set "${SET}" \
+    --kernel-name "${KERNEL_NAME}" \
+    --launch-skip "${LAUNCH_SKIP}" \
+    --launch-count "${LAUNCH_COUNT}" \
+    -o "${OUT}" \
+    "${PYTHON}" "${TARGET}" "${target_args[@]}" "$@"

--- a/profiling/cuda_path/run_nsys.sh
+++ b/profiling/cuda_path/run_nsys.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+TARGET="${SCRIPT_DIR}/target_symm_gemm_cuda.py"
+OUT_DIR="${SCRIPT_DIR}/results/nsys"
+
+PYTHON="${PYTHON:-python}"
+NSYS="${NSYS:-nsys}"
+M="${M:-4096}"
+WARMUP="${WARMUP:-5}"
+ITERS="${ITERS:-20}"
+DEVICE="${DEVICE:-cuda}"
+PROFILED="${PROFILED:-0}"
+NSYS_STATS="${NSYS_STATS:-1}"
+OUT="${OUT:-${OUT_DIR}/symm_gemm_cuda_m${M}_$(date +%Y%m%d_%H%M%S)}"
+
+mkdir -p "${OUT_DIR}"
+cd "${REPO_ROOT}"
+
+prewarm_args=(--m "${M}" --warmup 1 --iters 1 --device "${DEVICE}" --no-nvtx)
+target_args=(
+    --m "${M}"
+    --warmup "${WARMUP}"
+    --iters "${ITERS}"
+    --device "${DEVICE}"
+    --cuda-profiler-api
+)
+
+if [[ "${PROFILED}" == "1" ]]; then
+    prewarm_args+=(--profiled)
+    target_args+=(--profiled)
+fi
+
+echo "[nsys] prewarming JIT/cache outside Nsight..."
+"${PYTHON}" "${TARGET}" "${prewarm_args[@]}"
+
+echo "[nsys] writing ${OUT}.nsys-rep"
+"${NSYS}" profile \
+    --force-overwrite=true \
+    --trace=cuda,nvtx,osrt \
+    --sample=none \
+    --cpuctxsw=none \
+    --capture-range=cudaProfilerApi \
+    --capture-range-end=stop-shutdown \
+    -o "${OUT}" \
+    "${PYTHON}" "${TARGET}" "${target_args[@]}" "$@"
+
+if [[ "${NSYS_STATS}" == "1" ]]; then
+    echo "[nsys] summary stats"
+    "${NSYS}" stats "${OUT}.nsys-rep" || true
+fi

--- a/profiling/cuda_path/target_symm_gemm_cuda.py
+++ b/profiling/cuda_path/target_symm_gemm_cuda.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+import torch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from jit_kernel.thunder_moun import (  # noqa: E402
+    allocate_cuda_profiler_buffer,
+    estimate_cuda_profiler_records,
+    symm_gemm_block_scaled,
+)
+
+
+BLOCK_SIZE = 128
+DEFAULT_SEED = 42
+
+
+def ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def make_inputs(
+    m: int,
+    device: torch.device,
+    seed: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(seed)
+
+    x = torch.randn((m, m), dtype=torch.bfloat16, device=device)
+    xs_lhs = torch.ones(
+        (m, ceil_div(m, BLOCK_SIZE)), dtype=torch.float32, device=device
+    )
+    xs_rhs = torch.ones(
+        (ceil_div(m, BLOCK_SIZE), ceil_div(m, BLOCK_SIZE)),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    x_fp8 = x.to(torch.float8_e4m3fn)
+    w_fp8 = x.to(torch.float8_e4m3fn)
+    return x_fp8, w_fp8, xs_lhs, xs_rhs
+
+
+def maybe_start_cuda_profiler(enabled: bool) -> bool:
+    if not enabled:
+        return False
+    try:
+        torch.cuda.cudart().cudaProfilerStart()
+    except Exception as exc:
+        raise RuntimeError("failed to call cudaProfilerStart") from exc
+    return True
+
+
+def maybe_stop_cuda_profiler(started: bool) -> None:
+    if not started:
+        return
+    try:
+        torch.cuda.cudart().cudaProfilerStop()
+    except Exception as exc:
+        raise RuntimeError("failed to call cudaProfilerStop") from exc
+
+
+def maybe_push_nvtx(enabled: bool, message: str) -> bool:
+    if not enabled:
+        return False
+    torch.cuda.nvtx.range_push(message)
+    return True
+
+
+def maybe_pop_nvtx(pushed: bool) -> None:
+    if pushed:
+        torch.cuda.nvtx.range_pop()
+
+
+def unwrap_result(result: Any) -> torch.Tensor:
+    if isinstance(result, tuple):
+        return result[0]
+    return result
+
+
+def run_target(
+    *,
+    m: int,
+    warmup: int,
+    iters: int,
+    device: torch.device,
+    seed: int,
+    profiled: bool,
+    max_profiler_records: Optional[int],
+    cuda_profiler_api: bool,
+    nvtx: bool,
+    sync_each_iter: bool,
+) -> Tuple[float, float]:
+    if iters <= 0:
+        raise ValueError("iters must be positive")
+
+    x_fp8, w_fp8, xs_lhs, xs_rhs = make_inputs(m, device, seed)
+    out = torch.empty((m, m), dtype=torch.float16, device=device)
+
+    profiler_buffer = None
+    if profiled:
+        profiler_capacity = estimate_cuda_profiler_records(m, m, m)
+        if max_profiler_records is not None:
+            profiler_capacity = min(profiler_capacity, max_profiler_records)
+        profiler_buffer = allocate_cuda_profiler_buffer(profiler_capacity, device)
+
+    def run_once() -> torch.Tensor:
+        return unwrap_result(
+            symm_gemm_block_scaled(
+                x_fp8,
+                w_fp8,
+                xs_lhs,
+                xs_rhs,
+                out=out,
+                enable_cuda_profiler=profiled,
+                profiler_buffer=profiler_buffer,
+                max_profiler_records=max_profiler_records,
+            )
+        )
+
+    for _ in range(warmup):
+        run_once()
+    torch.cuda.synchronize(device)
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    profiler_started = False
+    nvtx_pushed = False
+    start_time = time.time()
+    try:
+        profiler_started = maybe_start_cuda_profiler(cuda_profiler_api)
+        nvtx_pushed = maybe_push_nvtx(nvtx, "ffjk_thunder_moun_cuda_path")
+
+        start_event.record()
+        for _ in range(iters):
+            run_once()
+            if sync_each_iter:
+                torch.cuda.synchronize(device)
+        end_event.record()
+        torch.cuda.synchronize(device)
+    finally:
+        maybe_pop_nvtx(nvtx_pushed)
+        maybe_stop_cuda_profiler(profiler_started)
+
+    host_ms = (time.time() - start_time) / iters * 1000.0
+    device_ms = start_event.elapsed_time(end_event) / iters
+    return host_ms, device_ms
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="External-profiler target for the ThunderMoun CUDA path."
+    )
+    parser.add_argument("--m", type=int, default=4096, help="Use M=N=K=m.")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
+        "--profiled",
+        action="store_true",
+        help="Run the embedded-profiler CUDA symbol instead of the normal path.",
+    )
+    parser.add_argument("--max-profiler-records", type=int, default=None)
+    parser.add_argument(
+        "--cuda-profiler-api",
+        action="store_true",
+        help="Call cudaProfilerStart/Stop around the measured loop.",
+    )
+    parser.add_argument(
+        "--no-nvtx",
+        action="store_true",
+        help="Do not add an NVTX range around the measured loop.",
+    )
+    parser.add_argument(
+        "--sync-each-iter",
+        action="store_true",
+        help="Synchronize after every measured kernel launch.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this target")
+
+    device = torch.device(args.device)
+    if device.type != "cuda":
+        raise ValueError("--device must be a CUDA device")
+    if device.index is not None:
+        torch.cuda.set_device(device)
+
+    stream = torch.cuda.Stream(device=device)
+    torch.cuda.set_stream(stream)
+
+    host_ms, device_ms = run_target(
+        m=args.m,
+        warmup=args.warmup,
+        iters=args.iters,
+        device=device,
+        seed=args.seed,
+        profiled=args.profiled,
+        max_profiler_records=args.max_profiler_records,
+        cuda_profiler_api=args.cuda_profiler_api,
+        nvtx=not args.no_nvtx,
+        sync_each_iter=args.sync_each_iter,
+    )
+
+    print("ThunderMoun CUDA path target")
+    print(f"target_kernel=hopper_symm_gemm_kernel_entry")
+    print(
+        f"M=N=K={args.m} warmup={args.warmup} iters={args.iters} "
+        f"profiled={args.profiled}"
+    )
+    print(f"device={torch.cuda.get_device_name(device)}")
+    print(f"host_ms_per_iter={host_ms:.6f}")
+    print(f"device_ms_per_iter={device_ms:.6f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds profiling support for the ThunderMoun CUDA symmetric GEMM path.

Changes:
- Add an embedded CUDA timestamp profiler for `hopper_symm_gemm_kernel_entry`.
- Keep the normal CUDA path unchanged unless `enable_cuda_profiler=True`.
- Add profiler buffer allocation, capacity estimation, decoding, summary reporting, and Chrome trace export.
- Add task-lane and CTA-lane Chrome trace views.
- Add a correctness probe comparing baseline CUDA output against the profiled CUDA path.
- Add standalone nsys/ncu targets for the CUDA path.

How to run:

- Embedded CUDA profiler + Chrome trace:
```bash
python jit_kernel/csrc/thunder_moun/bench_symm_gemm_cuda.py \
  --m 4096 \
  --warmup 5 \
  --iters 1 \
  --trace-json profiling/cuda_path/results/embedded/symm_m4096_trace.json
```

- Nsight Systems:
```bash
M=4096 WARMUP=5 ITERS=20 bash profiling/cuda_path/run_nsys.sh
```

- Nsight Compute:
```bash
M=4096 WARMUP=2 ITERS=1 SET=full bash profiling/cuda_path/run_ncu.sh
```