### PR TITLE
Fix import crash of topk_indexer on machines without CUDA

### DIFF
--- a/jit_kernel/topk_indexer.py
+++ b/jit_kernel/topk_indexer.py
@@ -16,10 +16,14 @@ _CPP_ENTRY = "fast_topk"
 _PY_SYMBOL = "fast_topk"
 
 common_cuda_flags = ["-O2"]
-if USE_TORCH_JIT:
-    major = torch.cuda.get_device_capability()[0]
-    if major > 9:
-        common_cuda_flags += ["-DENABLE_HOPPER=1", "-arch=sm_90"]
+
+if torch.cuda.is_available():
+    major, _minor = torch.cuda.get_device_capability()
+else:
+    major = 0
+
+if USE_TORCH_JIT and major > 9:
+    common_cuda_flags += ["-DENABLE_HOPPER=1", "-arch=sm_90"]
 
 @functools.cache
 def _jit_fast_topk_v3_module():


### PR DESCRIPTION
Fixes #13.

`import jit_kernel.topk_indexer` crashed with `AssertionError: Torch not compiled with CUDA enabled` on any CPU-only torch install, because `torch.cuda.get_device_capability()` ran at module import with no guard.

This applies the same `torch.cuda.is_available()` guard already used in `thunder_moun.py`. When CUDA is unavailable, `major` falls back to 0 so no Hopper flags are added, same as `thunder_moun.py`.

Verified: import fails on main, succeeds with this change on a CPU-only machine. No behavior change on CUDA machines, the flag logic is identical when a device is present.