### PR TITLE
FIx typos in README and jit_kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 </div>
 
-This repository is complemntary of "FlashFloat" with JIT Kernels
+This repository is complementary of "FlashFloat" with JIT Kernels
 
 <h2 id="highlight"> Highlight </h2>
 
@@ -21,9 +21,9 @@ This repository is complemntary of "FlashFloat" with JIT Kernels
 
 <h2 id="Ultra-Low-Latency-TopK-Indexer">🔥 Ultra Low Latency TopK Indexer</h2>
 
-The introduction of the NSA (Native Sparse Attention) mechanism in DeepSeek V3.2 has become pivotal for mitigating inference latency in long-context language modeling. While the NSA top-k indexer playing a critical role in reducing computational overhead for DeepSeek V32 long context sequence modeling task [1], DeepSeek V4 [2] [3], recently, further pushes the context window limit to 1 million tokens where selecting top-2048 dimensions in hybrid sparse attention along from upto 1-M context is a prohibitive bottlenect upto **0.1** ms per layer per query token for agentic workflow.
+The introduction of the NSA (Native Sparse Attention) mechanism in DeepSeek V3.2 has become pivotal for mitigating inference latency in long-context language modeling. While the NSA top-k indexer playing a critical role in reducing computational overhead for DeepSeek V32 long context sequence modeling task [1], DeepSeek V4 [2] [3], recently, further pushes the context window limit to 1 million tokens where selecting top-2048 dimensions in hybrid sparse attention along from up to 1-M context is a prohibitive bottleneck up to **0.1** ms per layer per query token for agentic workflow.
 
-Leveraging the latest SGLang (2026.3) as the benchmark, we investigated the root causes of this latency bottleneck: kernels for conventional throughput-optimized GPU designs suffer from low device utilization in low-batch yet long context decoding scenarios, due to insufficient inter-block coordination [4]. For example, on-chip network has been maturely adopted for many years in the processors such as Graphcore IPU, Cerebras WSE and Groq LPU, but only being introduced into Hopper lately since 2022. By exploiting the limited on-chip communication capabilities of the Hopper architecture  (upto 8 blocks per cluster), through hardware-aware alorithm-hardware co-design, we achieve more than **50%** latency reduction in low-batch yet long context decoding scenarios, demonstrating the effectiveness of synergistic optimization and **NoC** for long-context inference:
+Leveraging the latest SGLang (2026.3) as the benchmark, we investigated the root causes of this latency bottleneck: kernels for conventional throughput-optimized GPU designs suffer from low device utilization in low-batch yet long context decoding scenarios, due to insufficient inter-block coordination [4]. For example, on-chip network has been maturely adopted for many years in the processors such as Graphcore IPU, Cerebras WSE and Groq LPU, but only being introduced into Hopper lately since 2022. By exploiting the limited on-chip communication capabilities of the Hopper architecture  (up to 8 blocks per cluster), through hardware-aware algorithm-hardware co-design, we achieve more than **50%** latency reduction in low-batch yet long context decoding scenarios, demonstrating the effectiveness of synergistic optimization and **NoC** for long-context inference:
 
 **H100/H800**
 
@@ -45,28 +45,28 @@ Leveraging the latest SGLang (2026.3) as the benchmark, we investigated the root
 
 <br />
 
-We hence propose **Distributed Radix Sort via NoC** to extremely reduce decoding latency in workload of low batch size, yet with upto **1-M** context length. 
+We hence propose **Distributed Radix Sort via NoC** to extremely reduce decoding latency in workload of low batch size, yet with up to **1-M** context length. 
 
-- First we compute historgram in parallel to reduce collision rates per block and then accumulate the histogram via NoC network before N-ways prefix sum and prove this is an effective method to reduce latency for a throughput oriented hardware design. 
+- First we compute histogram in parallel to reduce collision rates per block and then accumulate the histogram via NoC network before N-ways prefix sum and prove this is an effective method to reduce latency for a throughput oriented hardware design. 
 
 - Second, we enhance the linear mapping properties for radix sort in **NSA** problem for reduction of radix sorting iterations; instead of traditional top **8/11/13** bits [9] of IEEE FP32, FP16 format, we redesign the linear mapping such that $bin(x) >= bin(y)$, naturally deducing $x >= y$. 
 
-  With this linear mapping design, we greatly reduced per block elements dropped in the threshold bin in redix sorting scheme and greatly reduce the residual numbers in later rounds.
+  With this linear mapping design, we greatly reduced per block elements dropped in the threshold bin in radix sorting scheme and greatly reduce the residual numbers in later rounds.
   
   This further facilitate cache friendly re-visiting over 1-M context length : we hence enable less **SMEM** in revisiting more elements.
 <br/>
 
-- Finally, when remainder elements reduced to **8**/**16**, we can simply use **CAS** operations to performa a **neat parallel sorting** in few cycles. This further reduce the latency overhead in the last round.
+- Finally, when remainder elements reduced to **8**/**16**, we can simply use **CAS** operations to perform a **neat parallel sorting** in few cycles. This further reduce the latency overhead in the last round.
 <br/>
 
-Previously, L2 cache was commonly used in NVGPU/AMD GPU to trackle the problem, for example in MoE Multi Block Block Size Align Sort Algorithm published 2025 [5], we tackle this problem by introducing mathematically equivalent **unaligned parallel prefix sum**. With distributed radix sort, we further prove that on-chip network can further reduce latency of our kernel, facilitating new design of algorithm and software for **1-M** context.
+Previously, L2 cache was commonly used in NVGPU/AMD GPU to tackle the problem, for example in MoE Multi Block Block Size Align Sort Algorithm published 2025 [5], we tackle this problem by introducing mathematically equivalent **unaligned parallel prefix sum**. With distributed radix sort, we further prove that on-chip network can further reduce latency of our kernel, facilitating new design of algorithm and software for **1-M** context.
 
 <br/>
 
-#### Compared to other works at the the time article is composing
+#### Compared to other works at the time article is composing
 
 ###### TLE DSL Topk (preview article April 09, 2026, community article April 17, 2026)
-Triton-TLE (Triton Language Extension) [TopK](https://github.com/flagos-ai/FlagTree/blob/f9a8d23602a65ec5c1af3b117e1faa46fe6f63b7/python/tutorials/tle/deepseek_v32/01-topk_selector.py#L3055) [6] [7], sits on the Pareto frontier of the prductivity and performance, filling the gap between our CUDA and other high-level DSL such as triton-Gluon and TileLang. It is highly efficient and elegant to utilize the **DSHMEM** to reduce the cross blocks communications lantency.
+Triton-TLE (Triton Language Extension) [TopK](https://github.com/flagos-ai/FlagTree/blob/f9a8d23602a65ec5c1af3b117e1faa46fe6f63b7/python/tutorials/tle/deepseek_v32/01-topk_selector.py#L3055) [6] [7], sits on the Pareto frontier of the productivity and performance, filling the gap between our CUDA and other high-level DSL such as triton-Gluon and TileLang. It is highly efficient and elegant to utilize the **DSHMEM** to reduce the cross blocks communications latency.
 
 The triton extension introduce the semantics explicitly visiting remote (tle.remote) blocks within the clusters via block-level device mesh (**tle.device_mesh**), cluster barriers (**tle.distributed_barrier**) and close loop on chip processing. While our native CUDA implementation offers peak performance, this DSL drastically simplifies the implementation complexity compared to manual CUDA coding.
 
@@ -90,12 +90,12 @@ On the other hand, tileLang excels in its pipelining mechanism, which enables ef
 ###### TRT-LLM (April 27, 2026)
 
 **Summary**
-Distinct from distribution-agnostic algorithm with Monolithtic Mapping, The Guess-Verify-Refine (GVR) algorithm [8] optimizes Top-K selection heuristicly for DeepSeek-V3.2 on NVIDIA Blackwell GPUs by reducing the nubmer dropping into the target threshold bin each round. 
+Distinct from distribution-agnostic algorithm with Monolithic Mapping, The Guess-Verify-Refine (GVR) algorithm [8] optimizes Top-K selection heuristically for DeepSeek-V3.2 on NVIDIA Blackwell GPUs by reducing the number dropping into the target threshold bin each round. 
 
-Pivoting from a blind search to a data-aware prediction, the techinique is built upon mathematic properties of Toeplitz matrix structure induced by RoPE in DS32 such that the prediction of radix step "t+1" highly relying on radix step "t".
+Pivoting from a blind search to a data-aware prediction, the technique is built upon mathematic properties of Toeplitz matrix structure induced by RoPE in DS32 such that the prediction of radix step "t+1" highly relying on radix step "t".
 
 **Single Pass Optimization**
-The kernel of the paper digests up to 60KB shared memory (4x share memory we actually used) and verified on SWE-bench-derived LongSeqTasks dataset to pre-compute candidates. That is if the data disbribution failed to pass **canUseHeuristic**, GVR TopK will not be called.
+The kernel of the paper digests up to 60KB shared memory (4x share memory we actually used) and verified on SWE-bench-derived LongSeqTasks dataset to pre-compute candidates. That is if the data distribution failed to pass **canUseHeuristic**, GVR TopK will not be called.
 
 Both SGLang and our implementation deliberately avoid primitives such as `__popc` and `__ballot_sync`. This architectural choice stems from the fact that warp-level voting can incur significant latencies, sometimes exceeding 30,000 cycles in high-contention scenarios [8].
 
@@ -109,11 +109,11 @@ Traditional ballot-based voting relies on expensive bit-shifting operations (a m
 ```
 
 **Compared to TRT-LLM production codebase**
-The whole algorithm is based on the earlier [two stages solution: topKPerRowDecode](https://github.com/NVIDIA/TensorRT-LLM/blame/v1.3.0rc10/cpp/tensorrt_llm/kernels/indexerTopK.cu), see [the details](https://github.com/NVIDIA/TensorRT-LLM/blame/628bb566050d693894ddf22de03581dd101747c3/cpp/tensorrt_llm/kernels/indexerTopK.cu#L743) in TRT-LLM **v1.3.0rc10**, this largely limited its peak perfmance in 1-M context scenarios.
+The whole algorithm is based on the earlier [two stages solution: topKPerRowDecode](https://github.com/NVIDIA/TensorRT-LLM/blame/v1.3.0rc10/cpp/tensorrt_llm/kernels/indexerTopK.cu), see [the details](https://github.com/NVIDIA/TensorRT-LLM/blame/628bb566050d693894ddf22de03581dd101747c3/cpp/tensorrt_llm/kernels/indexerTopK.cu#L743) in TRT-LLM **v1.3.0rc10**, this largely limited its peak performance in 1-M context scenarios.
 
 Recognizing this, the new approach [ballot-free kernel](https://github.com/NVIDIA/TensorRT-LLM/pull/12236) was integrated into TRT-LLM on March 16 2026. This implementation, written in cutedsl, leverages a Multi-CTA architecture with L2-cache-assisted synchronization to eliminate warp-level voting dependencies.
 
-Later a cluster specific multiple CTA supported [version](https://github.com/NVIDIA/TensorRT-LLM/pull/12354) also written in cudsl, was introduced into TRT-LLM in March 19 2026. The distributed shared memory accessing was supported via inline pseudo assembly PTX: 
+Later a cluster specific multiple CTA supported [version](https://github.com/NVIDIA/TensorRT-LLM/pull/12354) also written in cutedsl, was introduced into TRT-LLM in March 19 2026. The distributed shared memory accessing was supported via inline pseudo assembly PTX: 
 
 ```ptx
 mapa.shared::cluster.u32 dest_reg, src_shmem_ptr, target_cta_id
@@ -125,7 +125,7 @@ It’s worth noting that while the research paper still highlights Single-Pass/S
 
 [1] DeepSeek-AI V3.2 (2025.12). DeepSeek-V32 Technical Report: "Pushing the Frontier of Open Large Language Models", arXiv:2512.02556; Accessed on April 26, 2026
 
-[2] DeepSeek-AI V4 (2026). DeepSeek-V4 Technical Report: "Towards Highly Efficient Millon Token Context Intelligence", https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/DeepSeek_V4.pdf;  Accessed on April 26, 2026
+[2] DeepSeek-AI V4 (2026). DeepSeek-V4 Technical Report: "Towards Highly Efficient Million Token Context Intelligence", https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/DeepSeek_V4.pdf;  Accessed on April 26, 2026
 
 [3] Dissecting DeepSeek V4 ：https://www.zhihu.com/question/2030963929510310856/answer/2031157557008541232?share_code=1nP5rOshEmo63&utm_psn=2031815957111419327; Accessed on April 26, 2026
 

--- a/jit_kernel/topk_indexer.py
+++ b/jit_kernel/topk_indexer.py
@@ -61,7 +61,7 @@ def fast_topk_v3(
     """
     assert (
         topk == 2048
-    ), "fast_topk_v2 is only optimized for deepseek v3.2 model, where topk=2048"
+    ), "fast_topk_v3 is only optimized for deepseek v3.2 model, where topk=2048"
     assert score.dim() == 2
 
     # topk_indices = score.new_empty((score.size(0), topk), dtype=torch.int32)

--- a/jit_kernel/utils.py
+++ b/jit_kernel/utils.py
@@ -35,7 +35,7 @@ SUPPORTED_DEVICES = ["CUDA", "ROCm"]
 
 operator_namespace = "flash_float-jit-kernel"
 
-ommon_libs = ["c10", "torch", "torch_python"]
+common_libs = ["c10", "torch", "torch_python"]
 
 common_flags = [
     "-DNDEBUG",


### PR DESCRIPTION
Typo sweep, no functional changes.

- README: fixed misspellings (bottleneck, histogram, radix, algorithm, latency, productivity, technique, distribution, Million, performance, Monolithic, heuristically, complementary, tackle, perform), "upto" -> "up to", "cudsl" -> "cutedsl", removed a duplicated "the". URLs, tables, benchmark numbers and code blocks untouched.
- `topk_indexer.py`: assert message said `fast_topk_v2`, the function is `fast_topk_v3`.
- `utils.py`: `ommon_libs` -> `common_libs`. Grepped the repo, it's not referenced anywhere else, so the rename is safe.

Verified `import jit_kernel.utils` still works after the change.
