### PR TITLE
Add Triton 3.5 TVM-FFI launch paths

### DIFF
--- a/benchmark/moun/bench_triton_3_5_cuda_symm_gemm.py
+++ b/benchmark/moun/bench_triton_3_5_cuda_symm_gemm.py
@@ -185,6 +185,16 @@ def calculate_diff(m, dummy):
     print("diff (gluon tma ref): ", diff)
     torch.testing.assert_close(o_gluon_ref, o_torch_ref, rtol=5e-01, atol=1e-03)
 
+    o_gluon_tvm_ffi_ref = symm_gemm_op(x, use_tvm_ffi=True).cpu()
+
+    print("g_gluon_tvm_ffi_ref : ", o_gluon_tvm_ffi_ref)
+
+    diff = o_torch_ref - o_gluon_tvm_ffi_ref
+    print("diff (gluon tma tvm-ffi ref): ", diff)
+    torch.testing.assert_close(
+        o_gluon_tvm_ffi_ref, o_torch_ref, rtol=5e-01, atol=1e-03
+    )
+
     o_symm_fp8_tril = symm_gemm_block_scaled(
         xq.to(torch.float8_e4m3fn), wq.to(torch.float8_e4m3fn), xs_0, xs_1
     ).cpu()
@@ -261,6 +271,24 @@ def calculate_diff(m, dummy):
     gluon_ref_time = (time.time() - start) / iters * 1000
     gluon_ref_device_elapsed = start_event.elapsed_time(end_event) / iters
 
+    # === ThunderMuon Symm Gemm - baseline (Gluon TMA TVM-FFI) ===
+    for _ in range(warmup):
+        _ = symm_gemm_op(x, use_tvm_ffi=True)
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start = time.time()
+    start_event.record()
+    for _ in range(iters):
+        _ = symm_gemm_op(x, use_tvm_ffi=True)
+    end_event.record()
+    torch.cuda.synchronize()
+
+    gluon_tvm_ffi_ref_time = (time.time() - start) / iters * 1000
+    gluon_tvm_ffi_ref_device_elapsed = start_event.elapsed_time(end_event) / iters
+
     # === ThunderMuon Symm Gemm - baseline (CUDA) ===
     for _ in range(warmup):
         _ = symm_gemm_block_scaled(xq_fp8, wq_fp8, xs_0, xs_1)
@@ -289,6 +317,9 @@ def calculate_diff(m, dummy):
         f"Gluon TMA kernel             : {gluon_ref_time:.3f} ms, device {gluon_ref_device_elapsed:.3f} ms"
     )
     print(
+        f"Gluon TMA TVM-FFI kernel     : {gluon_tvm_ffi_ref_time:.3f} ms, device {gluon_tvm_ffi_ref_device_elapsed:.3f} ms"
+    )
+    print(
         f"Cuda Muon Symm Gemm          : {symm_gemm_time:.3f} ms, device {symm_gemm_device_elapsed:.3f} ms"
     )
     print(
@@ -311,12 +342,14 @@ configs = list(itertools.product(M, dummy))
             "torch",
             "triton_impl_ref",
             "gluon_muon_symm_gemm",
+            "gluon_muon_symm_gemm_tvm_ffi",
             "cuda_muon_symm_gemm",
         ],
         line_names=[
             "torch",
             "triton_muon_symm_gemm_ref",
             "gluon_muon_symm_gemm",
+            "gluon_muon_symm_gemm_tvm_ffi",
             "cuda_muon_symm_gemm (not optimized)",
         ],
         styles=[
@@ -365,6 +398,8 @@ def benchmark(m: int, dummy: int, provider) -> None:
         fn = lambda: XXT(x)
     elif provider == "gluon_muon_symm_gemm":
         fn = lambda: symm_gemm_op(x)
+    elif provider == "gluon_muon_symm_gemm_tvm_ffi":
+        fn = lambda: symm_gemm_op(x, use_tvm_ffi=True)
     elif provider == "cuda_muon_symm_gemm":
         fn = lambda: symm_gemm_block_scaled(x_fp8, wq_fp8, xs_0, xs_1)
 

--- a/jit_kernel/triton3_5/gluon/symm_gemm.py
+++ b/jit_kernel/triton3_5/gluon/symm_gemm.py
@@ -21,6 +21,13 @@ from triton.experimental.gluon.language.nvidia.hopper import (
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 
 
+USE_TVM_FFI = False
+
+tvm_ffi_modules = {
+    "XXT": None,
+}
+
+
 def is_hopper():
     if not torch.cuda.is_available():
         return False
@@ -188,7 +195,12 @@ def _pid_to_block(
     return batch_idx, m_idx, n_idx
 
 
-def XXT(A: torch.Tensor, out: torch.Tensor, use_gluon: bool = True):
+def XXT(
+    A: torch.Tensor,
+    out: torch.Tensor,
+    use_gluon: bool = True,
+    use_tvm_ffi: Optional[bool] = None,
+):
     """
     Launch Triton kernel to compute C = A @ A.T
     """
@@ -210,7 +222,7 @@ def XXT(A: torch.Tensor, out: torch.Tensor, use_gluon: bool = True):
         LOWER_UPPER=1,
     )
 
-    return gemm_op(A, out)
+    return gemm_op(A, out, use_tvm_ffi=use_tvm_ffi)
 
 
 @gluon.constexpr_function
@@ -431,6 +443,72 @@ def XXT_kernel(
     tma.store_wait(pendings=0)
 
 
+def _gluon_xxt_tvm_ffi(A, C, grid, kernel_kwargs, key):
+    import tvm_ffi
+
+    from jit_kernel.triton3_5.gluon.tvm_ffi_mod import (
+        flatten_tvm_ffi_args,
+        generate_tvm_ffi_source,
+    )
+
+    global tvm_ffi_modules
+
+    if tvm_ffi_modules["XXT"] is not None and key in tvm_ffi_modules["XXT"]:
+        module, kernel_name, compiled_kernel, gx, gy, gz = tvm_ffi_modules["XXT"][
+            key
+        ]
+    else:
+        compiled_kernel = XXT_kernel[grid](
+            kernel_kwargs["A_desc"],
+            kernel_kwargs["C_desc"],
+            M=kernel_kwargs["M"],
+            K=kernel_kwargs["K"],
+            BLOCK_SIZE_M=kernel_kwargs["BLOCK_SIZE_M"],
+            BLOCK_SIZE_N=kernel_kwargs["BLOCK_SIZE_N"],
+            BLOCK_SIZE_K=kernel_kwargs["BLOCK_SIZE_K"],
+            GROUP_SIZE_M=kernel_kwargs["GROUP_SIZE_M"],
+            LOWER_UPPER=kernel_kwargs["LOWER_UPPER"],
+            STAGES=kernel_kwargs["STAGES"],
+            num_warps=kernel_kwargs["num_warps"],
+        )
+        torch.cuda.synchronize()
+
+        cubin_bytes = compiled_kernel.kernel
+        kernel_name = compiled_kernel.name
+        sources, _constants = generate_tvm_ffi_source(compiled_kernel, kernel_name)
+
+        module = tvm_ffi.cpp.load_inline(
+            "triton3_5_gluon_xxt_loader",
+            cuda_sources=sources,
+            extra_ldflags=["-lcudart", "-lcuda"],
+            embed_cubin={"triton_cubin": cubin_bytes},
+        )
+
+        gx = int(grid[0])
+        gy = int(grid[1]) if len(grid) > 1 else 1
+        gz = int(grid[2]) if len(grid) > 2 else 1
+
+        if tvm_ffi_modules["XXT"] is None:
+            tvm_ffi_modules["XXT"] = {}
+
+        tvm_ffi_modules["XXT"][key] = (
+            module,
+            kernel_name,
+            compiled_kernel,
+            gx,
+            gy,
+            gz,
+        )
+
+    ffi_args = flatten_tvm_ffi_args(
+        compiled_kernel,
+        kernel_kwargs,
+        (gx, gy, gz),
+    )
+    getattr(module, kernel_name)(*ffi_args)
+    return C
+
+
 class GluonXXT:
     def __init__(
         self,
@@ -454,10 +532,11 @@ class GluonXXT:
         self.NUM_WARPS = NUM_WARPS
         self.LOWER_UPPER = LOWER_UPPER
 
-    # TODO (yiakwy) : cache TVM-FFI compiled result
-
     def __call__(
-        self, A: torch.Tensor, C: Optional[torch.Tensor] = None
+        self,
+        A: torch.Tensor,
+        C: Optional[torch.Tensor] = None,
+        use_tvm_ffi: Optional[bool] = None,
     ) -> torch.Tensor:
         M, K = A.shape[-2:]
 
@@ -481,6 +560,39 @@ class GluonXXT:
 
         num_pid_m = triton.cdiv(M, self.BLOCK_SIZE_M)
         grid = (batch_size * num_pid_m * num_pid_m,)
+
+        kernel_kwargs = {
+            "A_desc": A_desc,
+            "C_desc": C_desc,
+            "M": M,
+            "K": K,
+            "BLOCK_SIZE_M": self.BLOCK_SIZE_M,
+            "BLOCK_SIZE_N": self.BLOCK_SIZE_N,
+            "BLOCK_SIZE_K": self.BLOCK_SIZE_K,
+            "GROUP_SIZE_M": self.GROUP_SIZE_M,
+            "LOWER_UPPER": self.LOWER_UPPER,
+            "STAGES": self.STAGES,
+            "num_warps": self.NUM_WARPS,
+        }
+
+        use_ffi = USE_TVM_FFI if use_tvm_ffi is None else use_tvm_ffi
+        if use_ffi:
+            key = (
+                A.dtype,
+                C.dtype,
+                tuple(A.shape),
+                tuple(C.shape),
+                tuple(A.stride()),
+                tuple(C.stride()),
+                self.BLOCK_SIZE_M,
+                self.BLOCK_SIZE_N,
+                self.BLOCK_SIZE_K,
+                self.GROUP_SIZE_M,
+                self.LOWER_UPPER,
+                self.STAGES,
+                self.NUM_WARPS,
+            )
+            return _gluon_xxt_tvm_ffi(A, C, grid, kernel_kwargs, key)
 
         XXT_kernel[grid](
             A_desc,

--- a/jit_kernel/triton3_5/gluon/tvm_ffi_mod.py
+++ b/jit_kernel/triton3_5/gluon/tvm_ffi_mod.py
@@ -1,0 +1,425 @@
+import inspect
+import re
+
+from triton.experimental.gluon import language as gl
+
+
+TMA_DTYPE_DEVICE_TO_HOST = {i: i for i in range(16)}
+TMA_DTYPE_DEVICE_TO_HOST[8] = 10
+TMA_DTYPE_DEVICE_TO_HOST[9] = 8
+TMA_DTYPE_DEVICE_TO_HOST[10] = 9
+
+
+def is_constexpr_param(param):
+    ann = param.annotation
+    if ann is inspect._empty:
+        return False
+    return (
+        ann is gl.constexpr
+        or getattr(ann, "__name__", "") == "constexpr"
+        or "constexpr" in str(ann)
+    )
+
+
+def tensor_param_name(name):
+    if name.endswith("_desc"):
+        return name[: -len("_desc")]
+    return f"{name}_tensor"
+
+
+def cpp_scalar_type(sig):
+    return {
+        "i1": "int8_t",
+        "i8": "int8_t",
+        "i16": "int16_t",
+        "i32": "int32_t",
+        "i64": "int64_t",
+        "u1": "uint8_t",
+        "u8": "uint8_t",
+        "u16": "uint16_t",
+        "u32": "uint32_t",
+        "u64": "uint64_t",
+    }[sig]
+
+
+def arg_index(key):
+    return key[0] if isinstance(key, tuple) else key
+
+
+def tensordesc_rank(sig, fallback_rank):
+    match = re.match(r"tensordesc<([^[>]*)\[([^]]*)\]", sig)
+    if match is None:
+        return fallback_rank
+    return match.group(2).count(",") + 1
+
+
+def generate_desc_meta_by_name(compiled_kernel, desc_names, abi_sig_by_name):
+    desc_meta = compiled_kernel.metadata.tensordesc_meta
+    assert len(desc_meta) == len(desc_names)
+
+    desc_meta_by_name = {}
+    for name, meta in zip(desc_names, desc_meta):
+        block_size = list(meta["block_size"])
+        rank = tensordesc_rank(abi_sig_by_name[name], len(block_size))
+        desc_meta_by_name[name] = {
+            "name": name,
+            "rank": rank,
+            "swizzle": int(meta["swizzle"]),
+            "elem_size": int(meta["elem_size"]),
+            "elem_type": TMA_DTYPE_DEVICE_TO_HOST[int(meta["elem_type"])],
+            "block_size": [int(x) for x in block_size],
+        }
+    return desc_meta_by_name
+
+
+def generate_tensordesc_kernel_fields(name, rank):
+    fields = [f"    alignas(64) CUtensorMap {name};\n"]
+    fields.extend(f"    uint32_t {name}_shape_{i};\n" for i in range(rank))
+    fields.extend(f"    uint64_t {name}_stride_{i};\n" for i in range(rank))
+    return "".join(fields)
+
+
+def generate_scalar_kernel_field(name, sig):
+    return f"    {cpp_scalar_type(sig)} {name};\n"
+
+
+def generate_tensordesc_cpp_params(name, rank):
+    tensor_name = tensor_param_name(name)
+    params = [f"TensorView {tensor_name}"]
+    params.extend(f"int32_t {name}_shape_{i}" for i in range(rank))
+    params.extend(f"int64_t {name}_stride_{i}" for i in range(rank))
+    return params
+
+
+def generate_tensordesc_assignment(meta):
+    name = meta["name"]
+    rank = meta["rank"]
+    tensor_name = tensor_param_name(name)
+
+    shape_values = ", ".join(
+        f"static_cast<uint64_t>({name}_shape_{i})" for i in range(rank)
+    )
+    stride_values = ", ".join(
+        f"static_cast<uint64_t>({name}_stride_{i})" for i in range(rank)
+    )
+    block_values = ", ".join(str(x) for x in meta["block_size"])
+    shape_assignments = "".join(
+        f"    kargs.{name}_shape_{i} = static_cast<uint32_t>({name}_shape_{i});\n"
+        for i in range(rank)
+    )
+    stride_assignments = "".join(
+        f"    kargs.{name}_stride_{i} = static_cast<uint64_t>({name}_stride_{i});\n"
+        for i in range(rank)
+    )
+
+    return f"""
+    uint64_t {name}_shape[{rank}] = {{{shape_values}}};
+    uint64_t {name}_strides[{rank}] = {{{stride_values}}};
+    uint32_t {name}_block_size[{rank}] = {{{block_values}}};
+    EncodeTmaDescriptor(
+        &kargs.{name},
+        {tensor_name}.data_ptr(),
+        {meta["swizzle"]},
+        {meta["elem_size"]},
+        {meta["elem_type"]},
+        {rank},
+        {name}_block_size,
+        {name}_shape,
+        {name}_strides);
+{shape_assignments}{stride_assignments}"""
+
+
+def generate_scalar_assignment(name, sig):
+    return f"    kargs.{name} = static_cast<{cpp_scalar_type(sig)}>({name});\n"
+
+
+def flatten_tvm_ffi_args(compiled_kernel, kernel_kwargs, grid):
+    signature = compiled_kernel.src.fn.signature
+    flat_args = []
+
+    for name, param in signature.parameters.items():
+        if is_constexpr_param(param):
+            continue
+
+        value = kernel_kwargs[name]
+        if "desc" in name:
+            flat_args.append(value.base)
+            flat_args.extend(int(x) for x in value.shape)
+            flat_args.extend(int(x) for x in value.strides)
+        else:
+            flat_args.append(int(value))
+
+    flat_args.extend(
+        [
+            int(grid[0]),
+            int(grid[1]) if len(grid) > 1 else 1,
+            int(grid[2]) if len(grid) > 2 else 1,
+        ]
+    )
+    return flat_args
+
+
+# Triton 3.6 Gluon
+def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
+    if debug:
+        print(compiled_kernel.metadata)
+        print(compiled_kernel.asm["ptx"].split(".entry", 1)[1].split(")", 1)[0])
+
+    arg_names = compiled_kernel.src.fn.arg_names
+    signature = compiled_kernel.src.fn.signature
+
+    constants = {}
+    constants_set = set()
+    for key, val in compiled_kernel.src.constants.items():
+        idx = arg_index(key)
+        name = arg_names[idx]
+        constants[name] = (idx, val)
+        constants_set.add(name)
+
+    abi_sig_by_name = {}
+    for key, sig in compiled_kernel.src.signature.items():
+        abi_sig_by_name[key] = sig
+
+    desc_names = [
+        name
+        for name, param in signature.parameters.items()
+        if not is_constexpr_param(param) and "desc" in name
+    ]
+    desc_meta_by_name = generate_desc_meta_by_name(
+        compiled_kernel, desc_names, abi_sig_by_name
+    )
+
+    if debug:
+        print("arg_names : ", arg_names)
+        print("constants : ", constants)
+        print("abi_sig_by_name : ", abi_sig_by_name)
+
+    cpp_params = []
+    launch_args_def = []
+    launch_args = []
+    first_tensor_param = None
+
+    for name, param in signature.parameters.items():
+        # const param should not be added into cpp_params
+        if is_constexpr_param(param):
+            continue
+
+        sig = abi_sig_by_name[name]
+        if "desc" in name:
+            meta = desc_meta_by_name[name]
+            cpp_params.extend(generate_tensordesc_cpp_params(name, meta["rank"]))
+            if name in constants_set:
+                continue
+            launch_args_def.append(generate_tensordesc_kernel_fields(name, meta["rank"]))
+            launch_args.append(generate_tensordesc_assignment(meta))
+            if first_tensor_param is None:
+                first_tensor_param = tensor_param_name(name)
+        else:
+            cpp_params.append(f"{cpp_scalar_type(sig)} {name}")
+            if name in constants_set:
+                continue
+            launch_args_def.append(generate_scalar_kernel_field(name, sig))
+            launch_args.append(generate_scalar_assignment(name, sig))
+
+    META = compiled_kernel.metadata
+    global_scratch_size = getattr(META, "global_scratch_size", 0) or 0
+    global_scratch_align = getattr(META, "global_scratch_align", 1) or 1
+    profile_scratch_size = getattr(META, "profile_scratch_size", 0) or 0
+    profile_scratch_align = getattr(META, "profile_scratch_align", 1) or 1
+    if global_scratch_size != 0:
+        raise NotImplementedError(
+            f"Gluon TVM-FFI launcher does not allocate global scratch yet "
+            f"(size={global_scratch_size}, align={global_scratch_align})."
+        )
+    if profile_scratch_size != 0:
+        raise NotImplementedError(
+            f"Gluon TVM-FFI launcher does not allocate profile scratch yet "
+            f"(size={profile_scratch_size}, align={profile_scratch_align})."
+        )
+
+    launch_args_def.append("    CUdeviceptr global_scratch;\n")
+    launch_args.append("    kargs.global_scratch = 0;\n")
+    launch_args_def.append("    CUdeviceptr profile_scratch;\n")
+    launch_args.append("    kargs.profile_scratch = 0;\n")
+
+    cpp_params_str = ",\n    ".join(
+        cpp_params + ["int32_t grid_x", "int32_t grid_y", "int32_t grid_z"]
+    )
+    launch_args_def_str = "".join(launch_args_def)
+    launch_args_str = "".join(launch_args)
+
+    num_warps = META.num_warps
+    warp_size = META.target.warp_size
+    shared_mem_size = META.shared
+
+    source = f"""
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/extra/cuda/cubin_launcher.h>
+#include <tvm/ffi/function.h>
+
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+#include <cuda_runtime.h>
+#include <cuda.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+
+#define CHECK_CUDA_DRIVER_ERROR(call) \\
+    do {{ \\
+        CUresult err = call; \\
+        if (err != CUDA_SUCCESS) {{ \\
+            const char *err_name = nullptr; \\
+            const char *err_str = nullptr; \\
+            cuGetErrorName(err, &err_name); \\
+            cuGetErrorString(err, &err_str); \\
+            fprintf(stderr, "CUDA Driver Error at %s:%d: %s (%s)\\n", \\
+                    __FILE__, __LINE__, err_name, err_str); \\
+            fprintf(stderr, "Error code: %d\\n", err); \\
+            cuCtxSynchronize(); \\
+            throw std::runtime_error(std::string(err_name) + ", " + err_str); \\
+        }} \\
+    }} while(0)
+
+
+#define CHECK_CUDA_RUNTIME_ERROR(call) \\
+    do {{ \\
+        cudaError_t err = call; \\
+        if (err != cudaSuccess) {{ \\
+            const char *err_name = cudaGetErrorName(err); \\
+            const char *err_str = cudaGetErrorString(err); \\
+            fprintf(stderr, "CUDA Runtime Error at %s:%d: %s (%s)\\n", \\
+                    __FILE__, __LINE__, err_name, err_str); \\
+            fprintf(stderr, "Error code: %d\\n", err); \\
+            cudaDeviceSynchronize(); \\
+            throw std::runtime_error(std::string(err_name) + ", " + err_str); \\
+        }} \\
+    }} while(0)
+
+
+TVM_FFI_EMBED_CUBIN(triton_cubin);
+
+namespace triton_gluon_loader {{
+using namespace tvm::ffi;
+
+struct KernelArgs {{
+{launch_args_def_str}}};
+
+static void EncodeTmaDescriptor(
+    CUtensorMap* desc,
+    void* base_ptr,
+    int swizzle,
+    int elem_size,
+    int elem_type,
+    int rank,
+    const uint32_t* block_size,
+    const uint64_t* shape,
+    const uint64_t* strides) {{
+    if (strides[rank - 1] != 1) {{
+        throw std::runtime_error("TMA descriptor expects the innermost stride to be 1.");
+    }}
+
+    uint64_t global_dim[5] = {{0, 0, 0, 0, 0}};
+    uint64_t global_strides[5] = {{0, 0, 0, 0, 0}};
+    uint32_t box_dim[5] = {{1, 1, 1, 1, 1}};
+    uint32_t element_strides[5] = {{1, 1, 1, 1, 1}};
+
+    for (int i = 0; i < rank; ++i) {{
+        global_dim[rank - i - 1] = shape[i];
+        box_dim[rank - i - 1] = block_size[i];
+    }}
+    for (int i = 0; i + 1 < rank; ++i) {{
+        global_strides[rank - i - 2] =
+            static_cast<uint64_t>(elem_size) * strides[i];
+    }}
+    global_strides[rank - 1] =
+        global_dim[rank - 1] *
+        (rank == 1 ? static_cast<uint64_t>(elem_size)
+                   : global_strides[rank - 2]);
+
+    CUresult result = cuTensorMapEncodeTiled(
+        desc,
+        static_cast<CUtensorMapDataType>(elem_type),
+        static_cast<cuuint32_t>(rank),
+        base_ptr,
+        global_dim,
+        global_strides,
+        box_dim,
+        element_strides,
+        CU_TENSOR_MAP_INTERLEAVE_NONE,
+        static_cast<CUtensorMapSwizzle>(swizzle),
+        CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+        CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    CHECK_CUDA_DRIVER_ERROR(result);
+}}
+
+void {kernel_name}_launcher(
+    {cpp_params_str}) {{
+    static auto launcher = TVM_FFI_EMBED_CUBIN_GET_KERNEL(triton_cubin, "{kernel_name}");
+
+    KernelArgs kargs;
+
+{launch_args_str}
+    DLDevice device = {first_tensor_param}.device();
+
+    int shared_mem_bytes = {shared_mem_size};
+    shared_mem_bytes = (shared_mem_bytes + 7) & ~7;
+
+    int max_shared_mem_bytes;
+    CUresult get_attr_result = cuDeviceGetAttribute(
+        &max_shared_mem_bytes,
+        CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+        device.device_id);
+    CHECK_CUDA_DRIVER_ERROR(get_attr_result);
+
+    if (shared_mem_bytes > max_shared_mem_bytes) {{
+        max_shared_mem_bytes = shared_mem_bytes;
+    }}
+
+    CUfunction kernel = *(reinterpret_cast<CUfunction*>(&launcher));
+
+    cudaError_t set_attr_result = cudaFuncSetAttribute(
+        kernel,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        max_shared_mem_bytes);
+    CHECK_CUDA_RUNTIME_ERROR(set_attr_result);
+
+    cudaStream_t stream = static_cast<cudaStream_t>(
+        TVMFFIEnvGetStream(device.device_type, device.device_id));
+
+    tvm::ffi::dim3 grid(
+        static_cast<unsigned int>(grid_x),
+        static_cast<unsigned int>(grid_y),
+        static_cast<unsigned int>(grid_z));
+    tvm::ffi::dim3 block({num_warps * warp_size}, 1, 1);
+
+    size_t kargs_size = sizeof(KernelArgs);
+    void* config[] = {{
+        CU_LAUNCH_PARAM_BUFFER_POINTER, &kargs,
+        CU_LAUNCH_PARAM_BUFFER_SIZE, &kargs_size,
+        CU_LAUNCH_PARAM_END
+    }};
+
+    CUresult result = cuLaunchKernel(
+        kernel,
+        grid.x, grid.y, grid.z,
+        block.x, block.y, block.z,
+        static_cast<unsigned int>(shared_mem_bytes),
+        stream,
+        nullptr,
+        config);
+    if (result != CUDA_SUCCESS) {{
+        CHECK_CUDA_DRIVER_ERROR(result);
+    }}
+}}
+
+}} // namespace triton_gluon_loader
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    {kernel_name},
+    triton_gluon_loader::{kernel_name}_launcher);
+"""
+    return source, constants

--- a/jit_kernel/triton3_5/symm_gemm.py
+++ b/jit_kernel/triton3_5/symm_gemm.py
@@ -11,6 +11,13 @@ from packaging import version
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 
+USE_TVM_FFI = False
+
+tvm_ffi_modules = {
+    "XXT": None,
+}
+
+
 # NOTE (yiakwy) : useful for multiple-die chiplet architecture :
 #   - Blackwell(2 dies), Rubin(2 dies),
 #   - Rubin Ultra(4 dies), MI300(4 dies),
@@ -90,7 +97,8 @@ if version.parse(triton.__version__) < version.parse("3.6"):
         return new_pid
 
     @triton.jit
-    def swizzle2d(pid, grid_m, grid_n, GROUP_M: tl.constexpr):
+    def swizzle2d(pid_m, pid_n, grid_m, grid_n, GROUP_M: tl.constexpr):
+        pid = pid_m * grid_n + pid_n
         width = GROUP_M * grid_n
 
         group_id = pid // width
@@ -208,9 +216,121 @@ def XXT_kernel(
     tl.store(c_ptrs_t, output.T, mask=c_mask_t)
 
 
+def _xxt_config(K: int):
+    if K == 768:
+        return 128, 128, 64, 4, 8
+    return 64, 128, 128, 4, 8
+
+
+def _xxt_tvm_ffi(
+    A: torch.Tensor,
+    out: torch.Tensor,
+    M: int,
+    K: int,
+    batch_size: int,
+    input_batch_stride: int,
+    output_batch_stride: int,
+    BLOCK_SIZE_M: int,
+    BLOCK_SIZE_N: int,
+    BLOCK_SIZE_K: int,
+    num_stages: int,
+    num_warps: int,
+):
+    import tvm_ffi
+
+    from jit_kernel.triton3_5.tvm_ffi_mod import generate_tvm_ffi_source
+
+    global tvm_ffi_modules
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    key = (
+        str(A.dtype),
+        str(out.dtype),
+        M,
+        K,
+        batch_size,
+        input_batch_stride,
+        A.stride(-2),
+        A.stride(-1),
+        output_batch_stride,
+        out.stride(-2),
+        out.stride(-1),
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        num_stages,
+        num_warps,
+    )
+
+    if tvm_ffi_modules["XXT"] is not None and key in tvm_ffi_modules["XXT"]:
+        module, kernel_name, gx, gy, gz = tvm_ffi_modules["XXT"][key]
+    else:
+        compiled_kernel = XXT_kernel[grid](
+            A_ptr=A,
+            C_ptr=out,
+            M=M,
+            K=K,
+            a_stride_b=input_batch_stride,
+            a_stride_r=A.stride(-2),
+            a_stride_c=A.stride(-1),
+            c_stride_b=output_batch_stride,
+            c_stride_r=out.stride(-2),
+            c_stride_c=out.stride(-1),
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=8,
+            LOWER_UPPER=1,
+            num_stages=num_stages,
+            num_warps=num_warps,
+        )
+
+        cubin_bytes = compiled_kernel.kernel
+
+        kernel_name = compiled_kernel.name
+        sources, _constants = generate_tvm_ffi_source(compiled_kernel, kernel_name)
+
+        module = tvm_ffi.cpp.load_inline(
+            "triton3_5_xxt_loader",
+            cuda_sources=sources,
+            extra_ldflags=["-lcudart", "-lcuda"],
+            embed_cubin={"triton_cubin": cubin_bytes},
+        )
+
+        gx = int(grid[0])
+        gy = 1
+        gz = 1
+
+        if tvm_ffi_modules["XXT"] is None:
+            tvm_ffi_modules["XXT"] = {}
+
+        tvm_ffi_modules["XXT"][key] = (module, kernel_name, gx, gy, gz)
+
+    getattr(module, kernel_name)(
+        A,
+        out,
+        int(M),
+        int(K),
+        int(input_batch_stride),
+        int(A.stride(-2)),
+        int(A.stride(-1)),
+        int(output_batch_stride),
+        int(out.stride(-2)),
+        int(out.stride(-1)),
+        int(gx),
+        int(gy),
+        int(gz),
+    )
+    return out
+
+
 # TODO (yiakwy) : remove
 # adapted from modded_nanogpt as ref
-def XXT(A: torch.Tensor, out: Optional[torch.Tensor] = None):
+def XXT(
+    A: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    use_tvm_ffi: Optional[bool] = None,
+):
     """
     Launch Triton kernel to compute C = A @ A.T
     """
@@ -233,12 +353,24 @@ def XXT(A: torch.Tensor, out: Optional[torch.Tensor] = None):
     output_batch_stride = out.stride(0) if out.ndim == 3 else 0
 
     # Hardcoded configs based on H100 autotuning
-    if K == 768:
-        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
-        num_stages, num_warps = 4, 8
-    else:
-        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
-        num_stages, num_warps = 4, 8
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, num_stages, num_warps = _xxt_config(K)
+
+    use_ffi = USE_TVM_FFI if use_tvm_ffi is None else use_tvm_ffi
+    if use_ffi:
+        return _xxt_tvm_ffi(
+            A,
+            out,
+            M,
+            K,
+            batch_size,
+            input_batch_stride,
+            output_batch_stride,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            num_stages,
+            num_warps,
+        )
 
     grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
     XXT_kernel[grid](

--- a/jit_kernel/triton3_5/test_tvm_ffi_triton.py
+++ b/jit_kernel/triton3_5/test_tvm_ffi_triton.py
@@ -1,0 +1,54 @@
+import torch
+
+import jit_kernel.triton3_5.symm_gemm as s
+
+SEED = 42
+
+
+def test(m=2048, k=2048):
+    torch.manual_seed(SEED)
+
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    x = torch.randn((m, k), dtype=torch.bfloat16, device="cuda")
+    ref = torch.matmul(x.float(), x.float().T).to(torch.float16)
+    out = torch.empty((m, m), dtype=torch.float16, device="cuda")
+
+    s.tvm_ffi_modules["XXT"] = None
+
+    sentinel = -1234.0
+
+    # first call: compile, populate TVM-FFI cache, and launch once
+    print("first call : ...")
+    out.fill_(sentinel)
+    torch.cuda.synchronize()
+
+    s.XXT(x, out=out, use_tvm_ffi=True)
+    torch.cuda.synchronize()
+    remaining = (out == sentinel).sum().item()
+    print("[1st Write] sentinel remaining:", remaining)
+
+    assert (
+        remaining == 0
+    ), f"[1st Write] Expected kernel to overwrite all elements, but {remaining} remained sentinel"
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=1e-1)
+
+    # second call: cached TVM-FFI path
+    print("second call : ...")
+    out.fill_(sentinel)
+    torch.cuda.synchronize()
+
+    s.XXT(x, out=out, use_tvm_ffi=True)
+    torch.cuda.synchronize()
+    remaining = (out == sentinel).sum().item()
+    print("[2nd Write] sentinel remaining:", remaining)
+
+    assert (
+        remaining == 0
+    ), f"[2nd Write] Expected cached kernel to overwrite all elements, but {remaining} remained sentinel"
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=1e-1)
+
+
+if __name__ == "__main__":
+    test()

--- a/jit_kernel/triton3_5/tvm_ffi_mod.py
+++ b/jit_kernel/triton3_5/tvm_ffi_mod.py
@@ -1,0 +1,230 @@
+import inspect
+
+import triton.language as tl
+
+
+def is_constexpr_param(param):
+    ann = param.annotation
+    if ann is inspect._empty:
+        return False
+    return (
+        ann is tl.constexpr
+        or getattr(ann, "__name__", "") == "constexpr"
+        or "constexpr" in str(ann)
+    )
+
+
+def cpp_host_type(name: str) -> str:
+    if "ptr" in name:
+        return "TensorView"
+    if "use_" in name or "is_" in name:
+        return "bool"
+    return "int32_t"
+
+
+def kernel_arg_type(name: str) -> str:
+    if "ptr" in name:
+        return "void*"
+    if "use_" in name or "is_" in name:
+        return "bool"
+    return "int32_t"
+
+
+def kernel_arg_assignment(name: str) -> str:
+    if "ptr" in name:
+        return f"kargs.{name} = {name}.data_ptr();\n"
+    return f"kargs.{name} = {name};\n"
+
+
+# Triton 3.5
+def generate_tvm_ffi_source(compiled_kernel, kernel_name, debug=False):
+    if debug:
+        print(compiled_kernel.metadata)
+        print(compiled_kernel.asm["ptx"].split(".entry", 1)[1].split(")", 1)[0])
+
+    arg_names = compiled_kernel.src.fn.arg_names
+    signature = compiled_kernel.src.fn.signature
+
+    # TVM-FFI args list
+    cpp_params = []
+
+    # cuLaunchKernel arguemnt definition
+    launch_args_def = []
+    # cuLaunchKernel argsument assignment
+    launch_args = []
+
+    constants = {}
+    constants_set = set()
+    for key, val in compiled_kernel.src.constants.items():
+        name = arg_names[key[0]]
+
+        constants[name] = (key[0], val)
+        constants_set.add(name)
+
+    if debug:
+        print("arg_names : ", arg_names)
+        print("constants : ", constants)
+
+    for name, param in signature.parameters.items():
+        # const param should not be added into cpp_params
+        if is_constexpr_param(param):
+            continue
+
+        cpp_params.append(f"{cpp_host_type(name)} {name}")
+
+        # const in a compiled kernel should not be added into launch_args_def and launch_args
+        if name not in constants_set:
+            launch_args_def.append(f"{kernel_arg_type(name)} {name};\n")
+            launch_args.append(kernel_arg_assignment(name))
+
+    cpp_params_str = ", ".join(
+        cpp_params + ["int32_t grid_x", "int32_t grid_y", "int32_t grid_z"]
+    )
+
+    META = compiled_kernel.metadata
+
+    global_scratch_size = getattr(META, "global_scratch_size", 0) or 0
+    global_scratch_align = getattr(META, "global_scratch_align", 1) or 1
+    profile_scratch_size = getattr(META, "profile_scratch_size", 0) or 0
+    profile_scratch_align = getattr(META, "profile_scratch_align", 1) or 1
+    if global_scratch_size != 0:
+        raise NotImplementedError(
+            f"Triton 3.5 TVM-FFI launcher does not allocate global scratch yet "
+            f"(size={global_scratch_size}, align={global_scratch_align})."
+        )
+    if profile_scratch_size != 0:
+        raise NotImplementedError(
+            f"Triton 3.5 TVM-FFI launcher does not allocate profile scratch yet "
+            f"(size={profile_scratch_size}, align={profile_scratch_align})."
+        )
+
+    launch_args_def.append("CUdeviceptr global_scratch;\n")
+    launch_args.append("kargs.global_scratch = 0;\n")
+    launch_args_def.append("CUdeviceptr profile_scratch;\n")
+    launch_args.append("kargs.profile_scratch = 0;\n")
+
+    launch_args_def_str = "".join(launch_args_def)
+    launch_args_str = "".join(launch_args)
+
+    if debug:
+        print(f"cpp_params_str : {cpp_params_str}")
+        print(f"launch_args_def_str : {launch_args_def_str}")
+        print(f"launch_args_str : {launch_args_str}")
+
+    num_warps = META.num_warps  # compiled_kernel.num_warps
+    shared_mem_size = META.shared
+
+    WARP_SIZE = META.target.warp_size
+
+    source = f"""
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/extra/cuda/cubin_launcher.h>
+#include <tvm/ffi/function.h>
+
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+#include <cuda_runtime.h>
+#include <cuda.h>
+
+
+// NOTE (yiakwy) : for CUresult
+#define CHECK_CUDA_DRIVER_ERROR(call) \
+    do {{ \
+        CUresult err = call; \
+        if (err != CUDA_SUCCESS) {{ \
+            const char *err_name, *err_str; \
+            cuGetErrorName(err, &err_name); \
+            cuGetErrorString(err, &err_str); \
+            fprintf(stderr, "CUDA Driver Error at %s:%d: %s (%s)\\n", \
+                    __FILE__, __LINE__, err_name, err_str); \
+            fprintf(stderr, "Error code: %d\\n", err); \
+            cuCtxSynchronize(); \
+            throw std::runtime_error(std::string(err_name) + ", " + err_str); \
+        }} \
+    }} while(0)
+
+
+#define CHECK_CUDA_RUNTIME_ERROR(call) \
+    do {{ \
+        cudaError_t err = call; \
+        if (err != cudaSuccess) {{ \
+            const char *err_name, *err_str; \
+            err_name = cudaGetErrorName(err); \
+            err_str = cudaGetErrorString(err); \
+            fprintf(stderr, "CUDA Runtime Error at %s:%d: %s (%s)\\n", \
+                    __FILE__, __LINE__, err_name, err_str); \
+            fprintf(stderr, "Error code: %d\\n", err); \
+            cudaDeviceSynchronize(); \
+            throw std::runtime_error(std::string(err_name) + ", " + err_str); \
+        }} \
+    }} while(0)
+
+
+TVM_FFI_EMBED_CUBIN(triton_cubin);
+
+namespace triton_loader {{
+using namespace tvm::ffi;
+
+// NOTE (yiakwy) : TVM's official method does not handle alignment issue, hence I use this method to escape alignment problem.
+// We can also consider to modify TVM's official method to support alignment in the future if necessary.
+struct KernelArgs {{
+    {launch_args_def_str};
+}};
+
+void {kernel_name}_launcher({cpp_params_str}) {{
+    static auto launcher = TVM_FFI_EMBED_CUBIN_GET_KERNEL(triton_cubin, "{kernel_name}");
+
+    // construct Triton arguments list
+    KernelArgs kargs;
+
+    {launch_args_str};
+
+    DLDevice device = {arg_names[0]}.device();
+
+    int shared_mem_bytes = {shared_mem_size};
+    shared_mem_bytes = (shared_mem_bytes + 7) & ~7;
+
+    // NOTE (yiakwy) : use CUDA driver api
+    int max_shared_mem_bytes;
+    CUresult get_attr_result = cuDeviceGetAttribute(&max_shared_mem_bytes, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, device.device_id);
+    CHECK_CUDA_DRIVER_ERROR(get_attr_result);
+
+    // NOTE (yiakwy) : Hopper allows to set maximum share memory >= 483232 bytes
+    if (shared_mem_bytes > max_shared_mem_bytes) {{
+        max_shared_mem_bytes = shared_mem_bytes;
+    }}
+
+    CUfunction kernel = *(reinterpret_cast<CUfunction*>(&launcher));
+
+    // NOTE (yiakwy) : use cuda runtime api
+    cudaError_t set_attr_result = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem_bytes);
+    CHECK_CUDA_RUNTIME_ERROR(set_attr_result);
+
+    cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
+
+    tvm::ffi::dim3 grid((unsigned int)grid_x, (unsigned int)grid_y, (unsigned int)grid_z);
+    tvm::ffi::dim3 block({num_warps * WARP_SIZE}, 1, 1);
+
+    size_t kargs_size = sizeof(KernelArgs);
+    void* config[] = {{
+        CU_LAUNCH_PARAM_BUFFER_POINTER, &kargs,
+        CU_LAUNCH_PARAM_BUFFER_SIZE,    &kargs_size,
+        CU_LAUNCH_PARAM_END
+    }};
+
+    CUresult result = cuLaunchKernel(
+          kernel,
+          grid.x, grid.y, grid.z,
+          block.x, block.y, block.z,
+          (unsigned int)shared_mem_bytes, stream, nullptr, config);
+
+    if (result != CUDA_SUCCESS) {{
+        CHECK_CUDA_DRIVER_ERROR(result);
+    }}
+}}
+
+}} // namespace triton_loader
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC({kernel_name}, triton_loader::{kernel_name}_launcher);
+"""
+    return source, constants


### PR DESCRIPTION
This PR adds TVM-FFI launch paths for Triton 3.5 kernels under `jit_kernel/triton3_5`.


## Changes

- Add TVM-FFI launch support for the Triton 3.5 XXT kernel.
  - Native Triton launch remains the default.
  - TVM-FFI launch is enabled explicitly with `use_tvm_ffi=True`.
  - Includes the C++ wrapper/source generation needed to launch the compiled Triton cubin through TVM-FFI.

- Add a sentinel/correctness test for the Triton 3.5 XXT TVM-FFI path.
  - The test checks both first launch and cached launch.

- Add TVM-FFI launch support for Gluon XXT.
  - This path is adapted for the Triton 3.6 Gluon environment.
  - Native Gluon launch remains the default.
  - TVM-FFI launch is enabled explicitly with `use_tvm_ffi=True`.
  - Includes descriptor flattening and C++ `CUtensorMap` setup for the Gluon compiled cubin.

- Extend `benchmark/moun/bench_triton_3_5_cuda_symm_gemm.py` to include Gluon TVM-FFI results.
  - The benchmark keeps the same correctness/testing order as the existing Gluon native launcher path.
  - The new Gluon TVM-FFI result is reported alongside the existing Gluon native result.

## Notes

The regular Triton XXT TVM-FFI path is for Triton 3.5.

The Gluon TVM-FFI path is adapted for Triton 3.6 and is validated through `benchmark/moun/bench_triton_3_5_cuda_symm_gemm.py` using the same benchmark style as the existing Gluon native launcher.

Native launch remains the default in all cases.