### PR TITLE
Optimize ThunderMoun symmetric GEMM transpose and scaling

### DIFF
--- a/jit_kernel/csrc/thunder_moun/bench_symm_gemm.py
+++ b/jit_kernel/csrc/thunder_moun/bench_symm_gemm.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import itertools
+import os
+import sys
+from pathlib import Path
+
+import torch
+import triton
+import triton.testing
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from jit_kernel.thunder_moun import symm_gemm_block_scaled  # noqa: E402
+
+
+SEED = 42
+DEBUG = False
+
+IS_CI = (
+    os.getenv("CI", "false").lower() == "true"
+    or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+)
+
+
+def calculate_diff(m: int, dummy: int) -> None:
+    del dummy
+    torch.manual_seed(SEED)
+
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    x = torch.arange(m, dtype=torch.float16, device="cuda").view(1, -1) / (
+        m - 1
+    ) + torch.arange(m, dtype=torch.float16, device="cuda").view(-1, 1) / (m - 1)
+    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device="cuda")
+    xs_1 = torch.ones(
+        (triton.cdiv(m, 128), triton.cdiv(m, 128)),
+        dtype=torch.float32,
+        device="cuda",
+    )
+
+    x_fp8 = x.to(torch.float8_e4m3fn)
+    w_fp8 = x.to(torch.float8_e4m3fn)
+
+    o_torch_ref = x @ x.T
+    o_cuda = symm_gemm_block_scaled(x_fp8, w_fp8, xs_0, xs_1)
+
+    torch.testing.assert_close(o_cuda, o_torch_ref, rtol=5e-01, atol=1e-03)
+    print(f"PASS: {m}x{m}x{m} CUDA path matches the PyTorch baseline")
+    torch.cuda.synchronize()
+
+
+M = [2048, 4096, 8192]
+dummy = [1]
+configs = list(itertools.product(M, dummy))
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["m", "dummy"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=[
+            "torch",
+            "cuda_muon_symm_gemm",
+        ],
+        line_names=[
+            "torch",
+            "cuda_muon_symm_gemm",
+        ],
+        styles=[
+            ("red", "-"),
+            ("purple", "-"),
+        ],
+        ylabel="Latency",
+        plot_name="cuda-muon-symm-gemm-performance",
+        args={},
+    )
+)
+def benchmark(m: int, dummy: int, provider: str):
+    del dummy
+    torch.manual_seed(SEED)
+
+    stream = torch.cuda.Stream()
+    torch.cuda.set_stream(stream)
+
+    x = torch.randn(m, m, dtype=torch.bfloat16, device="cuda")
+    xs_0 = torch.ones((m, triton.cdiv(m, 128)), dtype=torch.float32, device="cuda")
+    xs_1 = torch.ones(
+        (triton.cdiv(m, 128), triton.cdiv(m, 128)),
+        dtype=torch.float32,
+        device="cuda",
+    )
+
+    x_fp8 = x.to(torch.float8_e4m3fn)
+    w_fp8 = x.to(torch.float8_e4m3fn)
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if provider == "torch":
+        fn = lambda: x @ x.T
+    elif provider == "cuda_muon_symm_gemm":
+        fn = lambda: symm_gemm_block_scaled(x_fp8, w_fp8, xs_0, xs_1)
+    else:
+        raise ValueError(f"Unsupported provider: {provider}")
+
+    for _ in range(10):
+        fn()
+    torch.cuda.synchronize()
+
+    ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
+    return ms * 1000, min_ms * 1000, max_ms * 1000
+
+
+if __name__ == "__main__":
+    test_configs = [configs[0]] if IS_CI else configs
+
+    for cfg in test_configs:
+        print(f"cfg : {cfg}")
+        calculate_diff(*cfg)
+
+    print("\n" + "=" * 60)
+    if not DEBUG:
+        print("Starting performance benchmark...")
+        benchmark.run(print_data=True)

--- a/jit_kernel/csrc/thunder_moun/block/nv_block_gemm_scaled_impl.h
+++ b/jit_kernel/csrc/thunder_moun/block/nv_block_gemm_scaled_impl.h
@@ -91,6 +91,13 @@ struct HopperPersistentSplitKPipeline {
         OutDtype* shmem_epilogue = reinterpret_cast<OutDtype *>(smem_buffer + STAGES * (BM * BK + BN * BK));
         FragmentView<OutDtype, BM, BN, MemoryDomain::kShared> frag_view(shmem_epilogue);
 
+#if !USE_INPALCE_TRI_TRANSPOSE
+        // Reuse X-stage storage after the mainloop has consumed every K tile.
+        static_assert(STAGES * sizeof(*shmem_X) >= BM * BN * sizeof(OutDtype),
+                      "X stage storage is too small for the transpose destination.");
+        OutDtype* shmem_transpose = reinterpret_cast<OutDtype*>(&shmem_X[0]);
+#endif
+
         constexpr uint32_t tma_bytes_X = BM * BK;
         constexpr uint32_t tma_bytes_W = BN * BK;
 
@@ -99,7 +106,7 @@ struct HopperPersistentSplitKPipeline {
         constexpr int SCLAE_BLOCK_SIZE_K = 128;
         constexpr int K_TILES_TOTAL = (8192 + SCLAE_BLOCK_SIZE_K - 1) / SCLAE_BLOCK_SIZE_K;
 
-        __shared__ __align__(128) float shmem_XS[BM * K_TILES_TOTAL];
+        __shared__ __align__(128) float shmem_XS[(BM + 1) * K_TILES_TOTAL]; // avoid bank conflicts
         __shared__ __align__(128) float shmem_WS[K_TILES_TOTAL];
 
         // TODO (yiakwy) : init full barriers for TMA, in mult-stages pipeline, we combine writer and reader barrieres in the same stage into one
@@ -259,7 +266,7 @@ struct HopperPersistentSplitKPipeline {
                 int g_row = block_idx_m * BM + s_row;
                 int g_col = (k_start + s_col) / shares_per_scale;
 
-                shmem_XS[s_col * BM + s_row] = scale_X[g_row * stride_xs_m + g_col];
+                shmem_XS[s_col * (BM + 1) + s_row] = scale_X[g_row * stride_xs_m + g_col];
             }
             __syncthreads();
 
@@ -330,8 +337,7 @@ struct HopperPersistentSplitKPipeline {
 
                 HopperWGMMAExecutor::commit_and_wait();
 
-                local_step_accum.mul_(&shmem_XS[0], &shmem_WS[0], k_tile - k_start);
-                accum.add_(local_step_accum);
+                accum.fma_scaled_(local_step_accum, &shmem_XS[0], &shmem_WS[0], k_tile - k_start);
                 __syncwarp();
 
                 read_stage = (read_stage + 1) % STAGES;
@@ -379,6 +385,10 @@ struct HopperPersistentSplitKPipeline {
                 }
             } //  split_k > 1
 
+#if !USE_INPALCE_TRI_TRANSPOSE
+            // Publish the reduced epilogue tile before the lower TMA store.
+            nvgpu::arch::tma_store_fence();
+#endif
             __syncthreads();
 
             if (split_k_id == 0) {
@@ -394,26 +404,37 @@ struct HopperPersistentSplitKPipeline {
                         "r"(block_idx_n * BN), "r"(block_idx_m * BM)
                         : "memory"
                     );
+#if !USE_INPALCE_TRI_TRANSPOSE
+                    asm volatile("cp.async.bulk.commit_group;\n" ::: "memory");
+#endif
                 }
 
 #if (defined(USE_LINEAR_TO_TRIL_LAYOUT)) && USE_LINEAR_TO_TRIL_LAYOUT
                 // NOTE (yiakwy) :  transpose copy to upper right
                 if (block_idx_m > block_idx_n) {
 
-#if (defined(USE_INPALCE_TRI_TRANSPOSE)) && USE_INPALCE_TRI_TRANSPOSE
+#if USE_INPALCE_TRI_TRANSPOSE
                     if (threadIdx.x == 0) {
                         asm volatile("cp.async.bulk.wait_group 0;\n" ::: "memory");
                     }
                     __syncthreads();
 
                     // NOTE (yiakwy) : inplace transpose
-                    frag_view._transpose();
+                    frag_view._transpose_opt_8x8();
 #else
-                    // NOTE (yiakwy) : outplace transpose
-                    // TODO (yiakwy) : outplace transpose
-#error "Outplace transpose is not implemented yet, please enable USE_INPALCE_TRI_TRANSPOSE to use inplace transpose."
+                    // The lower TMA store and transpose can read shmem_epilogue
+                    // concurrently because the transpose writes shmem_X.
+                    static_assert(SWIZZLE_64B_STORE == 0,
+                                  "out-of-place transpose only supports row-major TMA stores.");
+                    frag_view._transpose_outplace_opt_8x8(shmem_transpose);
 
 #endif // USE_INPALCE_TRI_TRANSPOSE
+
+#if !USE_INPALCE_TRI_TRANSPOSE
+                    // Publish the completed transpose before the upper TMA store.
+                    nvgpu::arch::tma_store_fence();
+                    __syncthreads();
+#endif
 
                     if (threadIdx.x == 0) {
 #if SWIZZLE_64B_STORE
@@ -421,7 +442,11 @@ struct HopperPersistentSplitKPipeline {
 #else
                         uint64_t tma_o_addr = reinterpret_cast<uint64_t>(tma_desc_O);
 #endif // SWIZZLE_64B_STORE
+#if USE_INPALCE_TRI_TRANSPOSE
                         uint32_t smem_epilogue_addr  = static_cast<uint32_t>(__cvta_generic_to_shared(&shmem_epilogue[0]));
+#else
+                        uint32_t smem_epilogue_addr  = static_cast<uint32_t>(__cvta_generic_to_shared(&shmem_transpose[0]));
+#endif
 
 #if SWIZZLE_64B_STORE
                         asm volatile (
@@ -453,6 +478,9 @@ struct HopperPersistentSplitKPipeline {
                             : "memory"
                         );
 #endif // SWIZZLE_64B_STORE
+#if !USE_INPALCE_TRI_TRANSPOSE
+                        asm volatile("cp.async.bulk.commit_group;\n" ::: "memory");
+#endif
                     }
 
                     asm volatile("fence.proxy.async.shared::cta;\n" ::: "memory");
@@ -460,6 +488,13 @@ struct HopperPersistentSplitKPipeline {
                 } // block_idx_m > block_idx_n
 
 #endif // USE_LINEAR_TO_TRIL_LAYOUT
+
+#if !USE_INPALCE_TRI_TRANSPOSE
+                if (threadIdx.x == 0) {
+                    // Drain output stores before the next task reuses shmem_X.
+                    asm volatile("cp.async.bulk.wait_group 0;\n" ::: "memory");
+                }
+#endif
 
             } // split_id == 0
             cluster.sync();

--- a/jit_kernel/csrc/thunder_moun/fragment/fragment.h
+++ b/jit_kernel/csrc/thunder_moun/fragment/fragment.h
@@ -4,6 +4,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 #pragma once
 #include <cuda_runtime.h>
+#include <stdint.h>
 
 #ifndef WARP_SIZE
 
@@ -108,23 +109,21 @@ struct FragmentView {
             } // end of sub_frag_idx_n
 
         } // end of sub_frag_idx_m
-        __syncthreads();
+        // __syncthreads();
+
+        //assume blockDim.x == 256
+        const int thr_row = tid >> 4;
+        const int thr_col = tid & 15;
 
         #pragma unroll
         for (int task_idx = 0; task_idx < M_STEPS; task_idx++) {
 
-            int sub_frag_idx_m_off = task_idx * FRAG_M;
-            int sub_frag_idx_n_off = task_idx * FRAG_M;
+            if (thr_col < thr_row) {
+                int row_src = task_idx * FRAG_M + thr_row;
+                int col_src = task_idx * FRAG_M + thr_col;
 
-            for (int pair_idx = tid; pair_idx < total_diagonal_pairs; pair_idx += threads_per_block) {
-                int thr_row = static_cast<int>((1 + __fsqrt_rn(1 + 8 * pair_idx)) / 2);
-                int thr_col = pair_idx - (thr_row * (thr_row - 1)) / 2;
-
-                int row_src = sub_frag_idx_m_off + thr_row;
-                int col_src = sub_frag_idx_n_off + thr_col;
-
-                int row_dst = sub_frag_idx_n_off + thr_col;
-                int col_dst = sub_frag_idx_m_off + thr_row;
+                int row_dst = task_idx * FRAG_M + thr_col;
+                int col_dst = task_idx * FRAG_M + thr_row;
 
                 int src_idx, dst_idx;
 
@@ -149,6 +148,161 @@ struct FragmentView {
         } // end of task_idx
 
         __syncthreads();
+    }
+
+    __device__ __forceinline__ static uint32_t warp_transpose_8x8_half2(
+        uint32_t packed,
+        int lane_id) {
+        const int out_row = lane_id / 4;
+        const int out_pair = lane_id % 4;
+
+        const int source_pair = out_row / 2;
+        const int half_select = out_row % 2;
+        const int bit_shift = half_select * 16;
+
+        const int source_lane_0 = (2 * out_pair) * 4 + source_pair;
+        const int source_lane_1 = (2 * out_pair + 1) * 4 + source_pair;
+
+        const uint32_t word_0 = __shfl_sync(0xffffffffu, packed, source_lane_0);
+        const uint32_t word_1 = __shfl_sync(0xffffffffu, packed, source_lane_1);
+
+        const uint32_t value_0 = (word_0 >> bit_shift) & 0xffffu;
+        const uint32_t value_1 = (word_1 >> bit_shift) & 0xffffu;
+        return value_0 | (value_1 << 16);
+    }
+
+    // Experimental row-major-only transpose using a direct 8x8 tiling.
+    __device__ inline void _transpose_opt_8x8() {
+        constexpr int TILE = 8;
+        constexpr int NUM_TILES = BM / TILE;
+        constexpr int TOTAL_OFFDIAGONAL_TILE_PAIRS =
+            NUM_TILES * (NUM_TILES - 1) / 2;
+        constexpr int WARPS_PER_CTA = 8;
+
+        static_assert(sizeof(T) == 2, "optimized transpose only supports 16-bit elements.");
+        static_assert(BM == BN, "inplace transpose can be only applied to square fragment.");
+        static_assert(BM % TILE == 0, "optimized transpose requires BM to be divisible by 8.");
+
+        const int lane_id = threadIdx.x % WARP_SIZE;
+        const int warp_id = threadIdx.x / WARP_SIZE;
+        const int lane_row = lane_id / 4;
+        const int lane_pair = lane_id % 4;
+        const int local_col = 2 * lane_pair;
+
+        // Each of the eight warps handles one off-diagonal 8x8 tile pair.
+        #pragma unroll
+        for (int pair_base = 0;
+             pair_base < TOTAL_OFFDIAGONAL_TILE_PAIRS;
+             pair_base += WARPS_PER_CTA) {
+            const int tile_pair_idx = pair_base + warp_id;
+
+            if (tile_pair_idx < TOTAL_OFFDIAGONAL_TILE_PAIRS) {
+                int tile_m = 1;
+
+                #pragma unroll
+                for (int candidate_m = 2; candidate_m < NUM_TILES; ++candidate_m) {
+                    if (tile_pair_idx >= candidate_m * (candidate_m - 1) / 2) {
+                        tile_m = candidate_m;
+                    }
+                }
+
+                const int tile_n =
+                    tile_pair_idx - tile_m * (tile_m - 1) / 2;
+
+                const int src_row_base = tile_m * TILE;
+                const int src_col_base = tile_n * TILE;
+                const int dst_row_base = tile_n * TILE;
+                const int dst_col_base = tile_m * TILE;
+
+                const int src_idx =
+                    (src_row_base + lane_row) * BM + src_col_base + local_col;
+                const int dst_idx =
+                    (dst_row_base + lane_row) * BM + dst_col_base + local_col;
+
+                const uint32_t src_old =
+                    *reinterpret_cast<const uint32_t*>(shared_ptr + src_idx);
+                const uint32_t dst_old =
+                    *reinterpret_cast<const uint32_t*>(shared_ptr + dst_idx);
+
+                const uint32_t src_t = warp_transpose_8x8_half2(src_old, lane_id);
+                const uint32_t dst_t = warp_transpose_8x8_half2(dst_old, lane_id);
+
+                *reinterpret_cast<uint32_t*>(shared_ptr + src_idx) = dst_t;
+                *reinterpret_cast<uint32_t*>(shared_ptr + dst_idx) = src_t;
+            }
+        }
+
+        // The same eight warps transpose the sixteen diagonal 8x8 tiles in two rounds.
+        #pragma unroll
+        for (int tile_base = 0; tile_base < NUM_TILES; tile_base += WARPS_PER_CTA) {
+            const int tile_idx = tile_base + warp_id;
+
+            if (tile_idx < NUM_TILES) {
+                const int row_base = tile_idx * TILE;
+                const int col_base = tile_idx * TILE;
+                const int packed_idx =
+                    (row_base + lane_row) * BM + col_base + local_col;
+
+                const uint32_t old_value =
+                    *reinterpret_cast<const uint32_t*>(shared_ptr + packed_idx);
+                const uint32_t transposed =
+                    warp_transpose_8x8_half2(old_value, lane_id);
+
+                *reinterpret_cast<uint32_t*>(shared_ptr + packed_idx) = transposed;
+            }
+        }
+
+        __syncthreads();
+    }
+
+    // Experimental row-major-only out-of-place transpose using direct 8x8 tiles.
+    __device__ inline void _transpose_outplace_opt_8x8(T* dst_shared_ptr) const {
+        constexpr int TILE = 8;
+        constexpr int NUM_TILES = BM / TILE;
+        constexpr int TOTAL_TILES = NUM_TILES * NUM_TILES;
+        constexpr int WARPS_PER_CTA = 8;
+
+        static_assert(sizeof(T) == 2, "optimized transpose only supports 16-bit elements.");
+        static_assert(BM == BN, "out-of-place transpose can be only applied to square fragment.");
+        static_assert(BM % TILE == 0, "optimized transpose requires BM to be divisible by 8.");
+
+        const int lane_id = threadIdx.x % WARP_SIZE;
+        const int warp_id = threadIdx.x / WARP_SIZE;
+        const int lane_row = lane_id / 4;
+        const int lane_pair = lane_id % 4;
+        const int local_col = 2 * lane_pair;
+
+        // Source and destination do not overlap. Each warp therefore handles one
+        // complete 8x8 tile rather than exchanging an off-diagonal tile pair.
+        #pragma unroll
+        for (int tile_base = 0;
+             tile_base < TOTAL_TILES;
+             tile_base += WARPS_PER_CTA) {
+            const int tile_idx = tile_base + warp_id;
+
+            if (tile_idx < TOTAL_TILES) {
+                const int src_tile_row = tile_idx / NUM_TILES;
+                const int src_tile_col = tile_idx % NUM_TILES;
+
+                const int src_row_base = src_tile_row * TILE;
+                const int src_col_base = src_tile_col * TILE;
+                const int dst_row_base = src_tile_col * TILE;
+                const int dst_col_base = src_tile_row * TILE;
+
+                const int src_idx =
+                    (src_row_base + lane_row) * BM + src_col_base + local_col;
+                const int dst_idx =
+                    (dst_row_base + lane_row) * BM + dst_col_base + local_col;
+
+                const uint32_t old_value =
+                    *reinterpret_cast<const uint32_t*>(shared_ptr + src_idx);
+                const uint32_t transposed =
+                    warp_transpose_8x8_half2(old_value, lane_id);
+
+                *reinterpret_cast<uint32_t*>(dst_shared_ptr + dst_idx) = transposed;
+            }
+        }
+
     }
 };
 

--- a/jit_kernel/csrc/thunder_moun/fragment/nv_frag_gemm_scaled_impl.h
+++ b/jit_kernel/csrc/thunder_moun/fragment/nv_frag_gemm_scaled_impl.h
@@ -184,7 +184,7 @@ struct HopperWGMMAAccumulator {
                 int row, col;
                 int _ = getTargetWgmmaSmemOffset(wg_id, wg_lane_id, i, m_step, M_STEPS, &row, &col);
 
-                float scale = xs[k_offset * BM + row] * _ws;
+                float scale = xs[k_offset * (BM + 1) + row] * _ws;
 
                 // if (threadIdx.x == 0) {
                 //     printf("[mul_] [Split#%d] [SM#%d] wg_id=%d, wg_lane_id=%d, reg_idx=%d, SmemFrag[%d, %d] = %f, scale_xs[%d]=%f, scale_ws[%d]=%f, final_scale=%f\n", blockIdx.x, blockIdx.y, wg_id, wg_lane_id, i, row, col, regs[m_step][i], row, xs[row], k_offset, _ws, scale);
@@ -209,6 +209,52 @@ struct HopperWGMMAAccumulator {
                 // }
                 // __syncthreads();
                 this->regs[m_step][i] += b.regs[m_step][i];
+            }
+        }
+    }
+
+    __device__ inline void fma_scaled_(const HopperWGMMAAccumulator& local, float* xs, float* ws, int k_offset = 0) {
+        const int warp_id = threadIdx.x / WARP_SIZE;
+        // const int lane_id = threadIdx.x % WARP_SIZE;
+
+        const int wg_id = warp_id / WARP_GROUP;
+        const int wg_lane_id = threadIdx.x % WARP_GROUP_SIZE;
+
+        const int wgs = blockDim.x / WARP_GROUP_SIZE;
+        const int M_STEPS = BM / FRAG_M / wgs;
+
+        float _ws = ws[k_offset];
+
+        const int warp_id_in_wg = wg_lane_id / WARP_SIZE;
+        const int lane_id = wg_lane_id % WARP_SIZE;
+
+        #pragma unroll
+        for (int m_step = 0; m_step < M_STEPS; ++m_step) {
+            const int row0 =
+                wg_id * FRAG_M * M_STEPS
+                + m_step * FRAG_M
+                + warp_id_in_wg * 16
+                + lane_id / 4;
+
+            const int row1 = row0 + 8;
+
+            const float scale0 = xs[k_offset * (BM + 1) + row0] * _ws;
+            const float scale1 = xs[k_offset * (BM + 1) + row1] * _ws;
+
+            #pragma unroll
+            for (int i = 0; i < (kRegistersPerThread / 4); ++i) {
+                const int base = 4 * i;
+                this->regs[m_step][base + 0] =
+                    __fmaf_rn(local.regs[m_step][base + 0], scale0, this->regs[m_step][base + 0]);
+
+                this->regs[m_step][base + 1] =
+                    __fmaf_rn(local.regs[m_step][base + 1], scale0, this->regs[m_step][base + 1]);
+
+                this->regs[m_step][base + 2] =
+                    __fmaf_rn(local.regs[m_step][base + 2], scale1, this->regs[m_step][base + 2]);
+
+                this->regs[m_step][base + 3] =
+                    __fmaf_rn(local.regs[m_step][base + 3], scale1, this->regs[m_step][base + 3]);
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR optimizes the ThunderMoun CUDA symmetric GEMM path by introducing direct 8×8 register-based transpose implementations and reducing scaling overhead in the WGMMA accumulation loop.

The optimized in-place transpose is enabled by default. A simple out-of-place implementation is also included for comparison and future pipeline work.

## Changes

### Direct 8×8 transpose

Add a warp-level 8×8 transpose helper for 16-bit elements:

* Each lane loads and stores one packed 32-bit pair.
* `__shfl_sync()` performs the 8×8 transpose in registers.
* Shared-memory operations remain row-major packed loads/stores.
* All eight CTA warps participate in processing tiles.

Add two transpose implementations:

* `_transpose_opt_8x8()`

  * Directly partitions the 128×128 tile into 8×8 tiles.
  * Exchanges off-diagonal tile pairs in place.
  * Transposes diagonal tiles in place.

* `_transpose_outplace_opt_8x8()`

  * Writes the transposed result into a separate shared-memory region.
  * Currently supports only square, 16-bit, row-major shared-memory layouts.

The original `_transpose()` remains available. Its diagonal-tile mapping is simplified to avoid floating-point square-root decoding and an unnecessary intermediate CTA synchronization.

### Simple out-of-place shared-memory reuse

The out-of-place path reuses the consumed `shmem_X` mainloop storage as the transpose destination, so it does not increase the kernel's dynamic shared-memory allocation.

The TMA lifecycle is updated for this path:

1. Fence the final epilogue writes before the lower TMA store.
2. Commit the lower TMA store.
3. Transpose from `shmem_epilogue` into `shmem_X`.
4. Fence and synchronize before the upper TMA store reads the transposed tile.
5. Commit the upper store.
6. Wait for output TMA completion before `shmem_X` is reused by the next task.

The lower TMA store and out-of-place transpose may read the epilogue tile concurrently because the transpose writes to a different shared-memory region.

## Benchmark

Add `jit_kernel/csrc/thunder_moun/bench_symm_gemm.py`, which:

* Checks the CUDA result against a PyTorch baseline.
* Benchmarks only the PyTorch baseline and ThunderMoun CUDA path.
* Covers matrix sizes 2048, 4096, and 8192.

## Performance

Measured on H100/SM90 using:

```bash
python jit_kernel/csrc/thunder_moun/bench_symm_gemm.py
```

Latency is reported in microseconds.

| Matrix size | Upstream main | In-place 8×8 | Improvement | Out-of-place 8×8 | Improvement |
|------------:|--------------:|-------------:|------------:|-----------------:|------------:|
| 2048        | 67.904        | 59.328       | 12.63%      | 60.832           | 10.41%      |
| 4096        | 250.464       | 216.128      | 13.71%      | 222.480          | 11.17%      |
| 8192        | 1607.104      | 1492.416     | 7.14%       | 1487.440         | 7.45%       |

Both transpose paths improve performance over upstream main for every tested size.

The in-place path performs best at 2048 and 4096. The out-of-place path is approximately 0.33% faster than in-place at 8192, although it is currently 2.5%–2.9% slower at the smaller sizes.
